### PR TITLE
refactor: move AnvilError to dedicated errors package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Anvil CLI
+# Anvil
 
 [![Go Version](https://img.shields.io/badge/go-1.17+-blue.svg)](https://golang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)

--- a/cmd/initcmd/init.go
+++ b/cmd/initcmd/init.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/rocajuanma/anvil/pkg/config"
 	"github.com/rocajuanma/anvil/pkg/constants"
+	"github.com/rocajuanma/anvil/pkg/errors"
 	"github.com/rocajuanma/anvil/pkg/terminal"
 	"github.com/rocajuanma/anvil/pkg/tools"
 	"github.com/spf13/cobra"
@@ -48,28 +49,28 @@ func runInitCommand() error {
 
 	// Ensure we're running on macOS
 	if runtime.GOOS != "darwin" {
-		return constants.NewAnvilError(constants.OpInit, "platform",
+		return errors.NewPlatformError(constants.OpInit, "platform",
 			fmt.Errorf("Anvil is only supported on macOS"))
 	}
 
 	// Stage 1: Tool validation and installation
 	terminal.PrintStage("Validating and installing required tools...")
 	if err := tools.ValidateAndInstallTools(); err != nil {
-		return constants.NewAnvilError(constants.OpInit, "validate-tools", err)
+		return errors.NewValidationError(constants.OpInit, "validate-tools", err)
 	}
 	terminal.PrintSuccess("All required tools are available")
 
 	// Stage 2: Create necessary directories
 	terminal.PrintStage("Creating necessary directories...")
 	if err := config.CreateDirectories(); err != nil {
-		return constants.NewAnvilError(constants.OpInit, "create-directories", err)
+		return errors.NewFileSystemError(constants.OpInit, "create-directories", err)
 	}
 	terminal.PrintSuccess("Directories created successfully")
 
 	// Stage 3: Generate default settings.yaml
 	terminal.PrintStage("Generating default settings.yaml...")
 	if err := config.GenerateDefaultSettings(); err != nil {
-		return constants.NewAnvilError(constants.OpInit, "generate-settings", err)
+		return errors.NewConfigurationError(constants.OpInit, "generate-settings", err)
 	}
 	terminal.PrintSuccess("Default settings.yaml generated")
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Configuration Caching** - Thread-safe configuration caching with double-checked locking pattern
 - **Context-Aware Commands** - Command execution with configurable timeouts to prevent hanging
-- **Structured Error Handling** - `AnvilError` struct with operation and command context
+- **Structured Error Handling** - `AnvilError` struct with operation, command context, and error types
 - **Constants Extraction** - Centralized constants for system commands, package names, and environment variables
 
 ### Changed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -105,7 +105,8 @@ anvil/
 ├── pkg/                   # Reusable packages
 │   ├── brew/              # Homebrew integration
 │   ├── config/            # Configuration management
-│   ├── constants/         # Application constants and error types
+│   ├── constants/         # Application constants
+│   ├── errors/            # Error types and structured error handling
 │   ├── figure/            # ASCII art generation
 │   ├── system/            # System command execution
 │   ├── terminal/          # Terminal output formatting
@@ -239,7 +240,7 @@ git checkout -b fix/issue-number-short-description
 Follow our development standards for:
 
 - **Package organization** - Use appropriate package structure with clear separation of concerns
-- **Error handling patterns** - Use `constants.AnvilError` for structured error handling with operation context
+- **Error handling patterns** - Use `errors.AnvilError` for structured error handling with operation context and error types
 - **Terminal output formatting** - Use `terminal` package for consistent output formatting
 - **Configuration management** - Use cached configuration access for optimal performance
 - **Constants usage** - Use constants from `pkg/constants/` instead of magic strings

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,36 +1,5 @@
 package constants
 
-import "fmt"
-
-// AnvilError represents a structured error with operation and command context
-type AnvilError struct {
-	Op      string
-	Command string
-	Err     error
-}
-
-// Error implements the error interface
-func (e *AnvilError) Error() string {
-	if e.Command != "" {
-		return fmt.Sprintf("anvil %s %s: %v", e.Op, e.Command, e.Err)
-	}
-	return fmt.Sprintf("anvil %s: %v", e.Op, e.Err)
-}
-
-// Unwrap returns the underlying error
-func (e *AnvilError) Unwrap() error {
-	return e.Err
-}
-
-// NewAnvilError creates a new AnvilError
-func NewAnvilError(op, command string, err error) *AnvilError {
-	return &AnvilError{
-		Op:      op,
-		Command: command,
-		Err:     err,
-	}
-}
-
 // Command operation constants
 const (
 	OpInit   = "init"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,173 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrorType represents different categories of errors
+type ErrorType int
+
+const (
+	// ErrorTypeGeneral represents general errors
+	ErrorTypeGeneral ErrorType = iota
+	// ErrorTypePlatform represents platform-specific errors
+	ErrorTypePlatform
+	// ErrorTypeValidation represents validation errors
+	ErrorTypeValidation
+	// ErrorTypeConfiguration represents configuration errors
+	ErrorTypeConfiguration
+	// ErrorTypeInstallation represents installation errors
+	ErrorTypeInstallation
+	// ErrorTypeNetwork represents network-related errors
+	ErrorTypeNetwork
+	// ErrorTypeFileSystem represents file system errors
+	ErrorTypeFileSystem
+)
+
+// String returns a string representation of the error type
+func (et ErrorType) String() string {
+	switch et {
+	case ErrorTypePlatform:
+		return "platform"
+	case ErrorTypeValidation:
+		return "validation"
+	case ErrorTypeConfiguration:
+		return "configuration"
+	case ErrorTypeInstallation:
+		return "installation"
+	case ErrorTypeNetwork:
+		return "network"
+	case ErrorTypeFileSystem:
+		return "filesystem"
+	default:
+		return "general"
+	}
+}
+
+// AnvilError represents a structured error with operation, command, and type context
+type AnvilError struct {
+	Op      string    // The operation being performed (init, setup, config, etc.)
+	Command string    // The specific command or subcommand
+	Type    ErrorType // The category of error
+	Err     error     // The underlying error
+	Context string    // Additional context information
+}
+
+// Error implements the error interface with improved formatting
+func (e *AnvilError) Error() string {
+	var parts []string
+
+	// Build the error prefix
+	if e.Command != "" {
+		parts = append(parts, fmt.Sprintf("anvil %s %s", e.Op, e.Command))
+	} else {
+		parts = append(parts, fmt.Sprintf("anvil %s", e.Op))
+	}
+
+	// Add error type if not general
+	if e.Type != ErrorTypeGeneral {
+		parts = append(parts, fmt.Sprintf("[%s]", e.Type.String()))
+	}
+
+	// Add context if available
+	if e.Context != "" {
+		parts = append(parts, fmt.Sprintf("(%s)", e.Context))
+	}
+
+	// Join with the error message
+	prefix := strings.Join(parts, " ")
+	return fmt.Sprintf("%s: %v", prefix, e.Err)
+}
+
+// Unwrap returns the underlying error
+func (e *AnvilError) Unwrap() error {
+	return e.Err
+}
+
+// Is checks if the error matches the target error type
+func (e *AnvilError) Is(target error) bool {
+	if t, ok := target.(*AnvilError); ok {
+		return e.Type == t.Type && e.Op == t.Op && e.Command == t.Command
+	}
+	return false
+}
+
+// NewAnvilError creates a new AnvilError with general type
+func NewAnvilError(op, command string, err error) *AnvilError {
+	return &AnvilError{
+		Op:      op,
+		Command: command,
+		Type:    ErrorTypeGeneral,
+		Err:     err,
+	}
+}
+
+// NewAnvilErrorWithType creates a new AnvilError with specified type
+func NewAnvilErrorWithType(op, command string, errType ErrorType, err error) *AnvilError {
+	return &AnvilError{
+		Op:      op,
+		Command: command,
+		Type:    errType,
+		Err:     err,
+	}
+}
+
+// NewAnvilErrorWithContext creates a new AnvilError with additional context
+func NewAnvilErrorWithContext(op, command, context string, errType ErrorType, err error) *AnvilError {
+	return &AnvilError{
+		Op:      op,
+		Command: command,
+		Type:    errType,
+		Context: context,
+		Err:     err,
+	}
+}
+
+// Helper functions for common error scenarios
+
+// NewPlatformError creates a platform-specific error
+func NewPlatformError(op, command string, err error) *AnvilError {
+	return NewAnvilErrorWithType(op, command, ErrorTypePlatform, err)
+}
+
+// NewValidationError creates a validation error
+func NewValidationError(op, command string, err error) *AnvilError {
+	return NewAnvilErrorWithType(op, command, ErrorTypeValidation, err)
+}
+
+// NewConfigurationError creates a configuration error
+func NewConfigurationError(op, command string, err error) *AnvilError {
+	return NewAnvilErrorWithType(op, command, ErrorTypeConfiguration, err)
+}
+
+// NewInstallationError creates an installation error
+func NewInstallationError(op, command string, err error) *AnvilError {
+	return NewAnvilErrorWithType(op, command, ErrorTypeInstallation, err)
+}
+
+// NewNetworkError creates a network error
+func NewNetworkError(op, command string, err error) *AnvilError {
+	return NewAnvilErrorWithType(op, command, ErrorTypeNetwork, err)
+}
+
+// NewFileSystemError creates a file system error
+func NewFileSystemError(op, command string, err error) *AnvilError {
+	return NewAnvilErrorWithType(op, command, ErrorTypeFileSystem, err)
+}
+
+// ErrorMatches checks if an error matches specific criteria
+func ErrorMatches(err error, op, command string, errType ErrorType) bool {
+	if anvilErr, ok := err.(*AnvilError); ok {
+		return anvilErr.Op == op && anvilErr.Command == command && anvilErr.Type == errType
+	}
+	return false
+}
+
+// GetErrorType extracts the error type from an AnvilError
+func GetErrorType(err error) ErrorType {
+	if anvilErr, ok := err.(*AnvilError); ok {
+		return anvilErr.Type
+	}
+	return ErrorTypeGeneral
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,155 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestAnvilError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *AnvilError
+		expected string
+	}{
+		{
+			name: "general error with command",
+			err: &AnvilError{
+				Op:      "init",
+				Command: "validate",
+				Type:    ErrorTypeGeneral,
+				Err:     errors.New("validation failed"),
+			},
+			expected: "anvil init validate: validation failed",
+		},
+		{
+			name: "platform error without command",
+			err: &AnvilError{
+				Op:   "setup",
+				Type: ErrorTypePlatform,
+				Err:  errors.New("unsupported platform"),
+			},
+			expected: "anvil setup [platform]: unsupported platform",
+		},
+		{
+			name: "installation error with context",
+			err: &AnvilError{
+				Op:      "setup",
+				Command: "homebrew",
+				Type:    ErrorTypeInstallation,
+				Context: "brew install git",
+				Err:     errors.New("installation failed"),
+			},
+			expected: "anvil setup homebrew [installation] (brew install git): installation failed",
+		},
+		{
+			name: "configuration error with all fields",
+			err: &AnvilError{
+				Op:      "config",
+				Command: "pull",
+				Type:    ErrorTypeConfiguration,
+				Context: "loading settings.yaml",
+				Err:     errors.New("file not found"),
+			},
+			expected: "anvil config pull [configuration] (loading settings.yaml): file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.expected {
+				t.Errorf("AnvilError.Error() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewAnvilError(t *testing.T) {
+	err := NewAnvilError("init", "validate", fmt.Errorf("test error"))
+
+	if err.Op != "init" {
+		t.Errorf("Expected Op to be 'init', got %s", err.Op)
+	}
+
+	if err.Command != "validate" {
+		t.Errorf("Expected Command to be 'validate', got %s", err.Command)
+	}
+
+	if err.Type != ErrorTypeGeneral {
+		t.Errorf("Expected Type to be ErrorTypeGeneral, got %v", err.Type)
+	}
+
+	if err.Err.Error() != "test error" {
+		t.Errorf("Expected underlying error to be 'test error', got %s", err.Err.Error())
+	}
+}
+
+func TestNewPlatformError(t *testing.T) {
+	err := NewPlatformError("setup", "install", fmt.Errorf("unsupported OS"))
+
+	if err.Type != ErrorTypePlatform {
+		t.Errorf("Expected Type to be ErrorTypePlatform, got %v", err.Type)
+	}
+
+	expected := "anvil setup install [platform]: unsupported OS"
+	if err.Error() != expected {
+		t.Errorf("Expected error string to be '%s', got '%s'", expected, err.Error())
+	}
+}
+
+func TestErrorMatches(t *testing.T) {
+	err := NewAnvilErrorWithType("init", "validate", ErrorTypeValidation, fmt.Errorf("validation failed"))
+
+	if !ErrorMatches(err, "init", "validate", ErrorTypeValidation) {
+		t.Error("Expected ErrorMatches to return true for matching error")
+	}
+
+	if ErrorMatches(err, "setup", "validate", ErrorTypeValidation) {
+		t.Error("Expected ErrorMatches to return false for different operation")
+	}
+
+	if ErrorMatches(err, "init", "install", ErrorTypeValidation) {
+		t.Error("Expected ErrorMatches to return false for different command")
+	}
+
+	if ErrorMatches(err, "init", "validate", ErrorTypePlatform) {
+		t.Error("Expected ErrorMatches to return false for different error type")
+	}
+}
+
+func TestGetErrorType(t *testing.T) {
+	err := NewInstallationError("setup", "homebrew", fmt.Errorf("installation failed"))
+
+	if GetErrorType(err) != ErrorTypeInstallation {
+		t.Errorf("Expected GetErrorType to return ErrorTypeInstallation, got %v", GetErrorType(err))
+	}
+
+	// Test with non-AnvilError
+	regularErr := fmt.Errorf("regular error")
+	if GetErrorType(regularErr) != ErrorTypeGeneral {
+		t.Errorf("Expected GetErrorType to return ErrorTypeGeneral for non-AnvilError, got %v", GetErrorType(regularErr))
+	}
+}
+
+func TestErrorTypeString(t *testing.T) {
+	tests := []struct {
+		errType  ErrorType
+		expected string
+	}{
+		{ErrorTypeGeneral, "general"},
+		{ErrorTypePlatform, "platform"},
+		{ErrorTypeValidation, "validation"},
+		{ErrorTypeConfiguration, "configuration"},
+		{ErrorTypeInstallation, "installation"},
+		{ErrorTypeNetwork, "network"},
+		{ErrorTypeFileSystem, "filesystem"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.errType.String(); got != tt.expected {
+				t.Errorf("ErrorType.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Create new pkg/errors package with enhanced error handling
- Add ErrorType enum for categorizing errors (platform, validation, configuration, installation, network, filesystem)
- Enhance AnvilError struct with Type and Context fields for better error context
- Improve error formatting with contextual information and type indicators
- Add helper functions for common error scenarios:
  - NewPlatformError, NewValidationError, NewConfigurationError
  - NewInstallationError, NewNetworkError, NewFileSystemError
- Add utility functions: ErrorMatches, GetErrorType
- Remove AnvilError from constants package for better separation of concerns
- Update cmd/initcmd/init.go to use specific error types
- Update cmd/setup/setup.go to use specific error types an