### PR TITLE
feat: add Apache License 2.0 headers to all source files

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/cmd/draw/draw.go
+++ b/cmd/draw/draw.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package draw
 
 import (

--- a/cmd/pull/pull.go
+++ b/cmd/pull/pull.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pull
 
 import (

--- a/cmd/push/push.go
+++ b/cmd/push/push.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package push
 
 import (

--- a/pkg/brew/brew.go
+++ b/pkg/brew/brew.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package brew
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package constants
 
 // Command operation constants

--- a/pkg/constants/descriptions.go
+++ b/pkg/constants/descriptions.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package constants
 
 // Long descriptions for commands

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package errors
 
 import (

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package errors
 
 import (

--- a/pkg/figure/figure.go
+++ b/pkg/figure/figure.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package figure
 
 import (

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package system
 
 import (

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package terminal
 
 import (

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tools
 
 import (


### PR DESCRIPTION
Add consistent copyright headers to all Go source files that were missing them:

- pkg/errors/errors.go and errors_test.go
- pkg/system/system.go
- pkg/terminal/terminal.go
- pkg/tools/tools.go
- pkg/figure/figure.go
- pkg/brew/brew.go
- pkg/constants/constants.go and descriptions.go
- pkg/config/config.go and config_test.go
- cmd/push/push.go
- cmd/draw/draw.go
- cmd/pull/pull.go
- cmd/config/config.go

All headers follow the standard Apache License 2.0 format with:
- Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
- Full Apache License 2.0 text and permissions

This ensures consistent legal attribution across the entire codebase and follows open source best practices for license compliance.