### PR TITLE
feat: rename setup command to install and enhance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supercharge your macOS development setup with Anvil — the all-in-one CLI for e
 
 ## ✨ Features
 
-- **🎯 Dynamic Installation** - Install any macOS application with `anvil setup [app-name]`
+- **🎯 Dynamic Installation** - Install any macOS application with `anvil install [app-name]`
 - **📝 Smart Tracking** - Individual apps automatically tracked in `tools.installed_apps`
 - **📦 Group Management** - Predefined and custom tool groups for common scenarios
 - **🚀 Zero Configuration** - Works out of the box with sensible defaults
@@ -48,15 +48,15 @@ sudo mv anvil /usr/local/bin/
 anvil init
 
 # Install applications dynamically
-anvil setup firefox
-anvil setup visual-studio-code
+anvil install firefox
+anvil install visual-studio-code
 
 # Install predefined tool groups
-anvil setup dev        # git, zsh, iterm2, visual-studio-code
-anvil setup new-laptop # slack, google-chrome, 1password
+anvil install dev        # git, zsh, iterm2, visual-studio-code
+anvil install new-laptop # slack, google-chrome, 1password
 
 # Preview before installing
-anvil setup docker --dry-run
+anvil install docker --dry-run
 ```
 
 ## 📋 Installation Methods
@@ -66,9 +66,9 @@ anvil setup docker --dry-run
 Install any Homebrew package by name with automatic tracking:
 
 ```bash
-anvil setup firefox
-anvil setup slack
-anvil setup figma
+anvil install firefox
+anvil install slack
+anvil install figma
 ```
 
 ### Predefined Groups
@@ -104,7 +104,7 @@ anvil config push cursor
 
 📖 **[Complete Setup Guide](docs/config-readme.md)** - Authentication, repository structure, and examples
 
-## ⚙️ Configuration
+## ⚙️ Settings
 
 Basic settings structure in `~/.anvil/settings.yaml`:
 
@@ -128,10 +128,11 @@ github:
 | Command             | Description            | Example                    |
 | ------------------- | ---------------------- | -------------------------- |
 | `init`              | Initialize environment | `anvil init`               |
-| `setup [app]`       | Install application    | `anvil setup firefox`      |
-| `setup [group]`     | Install tool group     | `anvil setup dev`          |
-| `setup --list`      | List available groups  | `anvil setup --list`       |
+| `install [app]`     | Install application    | `anvil install firefox`    |
+| `install [group]`   | Install tool group     | `anvil install dev`        |
+| `install --list`    | List available groups  | `anvil install --list`     |
 | `config pull [dir]` | Pull configurations    | `anvil config pull cursor` |
+| `config push [dir]` | Push configurations    | `anvil config push cursor` |
 
 ### Useful Flags
 
@@ -145,7 +146,7 @@ github:
 | **[Getting Started](docs/GETTING_STARTED.md)**        | Complete setup and usage guide |
 | **[Configuration Management](docs/config-readme.md)** | Dotfiles sync with GitHub      |
 | **[Examples & Tutorials](docs/EXAMPLES.md)**          | Real-world usage scenarios     |
-| **[Setup Command](docs/setup-readme.md)**             | Detailed installation options  |
+| **[Install Command](docs/install-readme.md)**         | Detailed installation options  |
 | **[Contributing](docs/CONTRIBUTING.md)**              | Development guidelines         |
 | **[Changelog](docs/CHANGELOG.md)**                    | Version history and updates    |
 

--- a/cmd/initcmd/init.go
+++ b/cmd/initcmd/init.go
@@ -102,8 +102,8 @@ func runInitCommand() error {
 
 	// Final usage guidance
 	terminal.PrintInfo("\nYou can now use:")
-	terminal.PrintInfo("  • 'anvil setup [group]' to install development tool groups")
-	terminal.PrintInfo("  • 'anvil setup [app]' to install any individual application")
+	terminal.PrintInfo("  • 'anvil install [group]' to install development tool groups")
+	terminal.PrintInfo("  • 'anvil install [app]' to install any individual application")
 	terminal.PrintInfo("  • Edit %s/settings.yaml to customize your configuration", config.GetConfigDirectory())
 
 	// GitHub configuration warning
@@ -123,7 +123,7 @@ func runInitCommand() error {
 	} else {
 		terminal.PrintInfo("\nAvailable groups: dev, new-laptop")
 	}
-	terminal.PrintInfo("Example: 'anvil setup dev' or 'anvil setup firefox'")
+	terminal.PrintInfo("Example: 'anvil install dev' or 'anvil install firefox'")
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,8 @@ import (
 	"os"
 
 	"github.com/rocajuanma/anvil/cmd/config"
-	"github.com/rocajuanma/anvil/cmd/draw"
 	"github.com/rocajuanma/anvil/cmd/initcmd"
-	"github.com/rocajuanma/anvil/cmd/setup"
+	"github.com/rocajuanma/anvil/cmd/install"
 	"github.com/rocajuanma/anvil/pkg/constants"
 	"github.com/rocajuanma/anvil/pkg/figure"
 	"github.com/spf13/cobra"
@@ -50,16 +49,8 @@ func Execute() {
 
 func init() {
 	rootCmd.AddCommand(initcmd.InitCmd)
-	rootCmd.AddCommand(setup.SetupCmd)
+	rootCmd.AddCommand(install.InstallCmd)
 	rootCmd.AddCommand(config.ConfigCmd)
-	rootCmd.AddCommand(draw.DrawCmd)
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.anvil.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
+	//rootCmd.AddCommand(draw.DrawCmd)
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Simplified Groups Structure** - Removed "custom:" header requirement, all groups now at the same level in settings.yaml
-- **Automatic App Tracking** - Individual apps installed via `anvil setup [app-name]` are automatically tracked in `tools.installed_apps`
+- **Automatic App Tracking** - Individual apps installed via `anvil install [app-name]` are automatically tracked in `tools.installed_apps`
 - **Smart Duplicate Prevention** - Prevents tracking apps already in groups, required_tools, or optional_tools
 - **Dynamic Individual Installation** - Install any Homebrew package by name with automatic tracking
 - **Configuration Pull System** - Complete implementation of `anvil config pull [directory]` command
@@ -39,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING CHANGE**: Individual app installation approach - Replaced flag-based installation (`--git`, `--zsh`) with dynamic name-based installation (`anvil setup git`, `anvil setup zsh`)
+- **BREAKING CHANGE**: Command renamed from `setup` to `install` - All `anvil setup` commands are now `anvil install`
+- **BREAKING CHANGE**: Individual app installation approach - Replaced flag-based installation (`--git`, `--zsh`) with dynamic name-based installation (`anvil install git`, `anvil install zsh`)
 - **BREAKING CHANGE**: Groups configuration structure - Removed "custom:" header requirement, all groups now at the same level in settings.yaml
 - **BREAKING CHANGE**: Reorganized `pull` and `push` commands as subcommands of `config`
   - `anvil pull` → `anvil config pull [directory]`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,7 +97,6 @@ anvil/
 ├── cmd/                    # Command implementations
 │   ├── initcmd/           # Init command
 │   ├── setup/             # Setup command
-│   ├── draw/              # Draw command
 │   ├── config/            # Config command (parent for pull/push)
 │   │   ├── pull/          # Pull subcommand (config pull)
 │   │   └── push/          # Push subcommand (config push)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -31,7 +31,7 @@ $ anvil init
 ✅ Default settings.yaml generated
 
 # Step 2: See what tools are available
-$ anvil setup --list
+$ anvil install --list
 
 === Available Setup Groups ===
 Group: dev
@@ -46,7 +46,7 @@ Group: new-laptop
   • 1password
 
 # Step 3: Install development tools
-$ anvil setup dev
+$ anvil install dev
 
 === Setting up 'dev' group ===
 Installing tools for group 'dev': git, zsh, iterm2, vscode
@@ -70,7 +70,7 @@ Successfully installed 4 of 4 tools in group 'dev'
 
 ```bash
 # Preview what would be installed
-$ anvil setup dev --dry-run
+$ anvil install dev --dry-run
 
 Dry run mode - no actual installations will be performed
 
@@ -82,7 +82,7 @@ Would install: git
 Would install: zsh
 
 # Install the tools
-$ anvil setup dev
+$ anvil install dev
 
 === Individual Tool Setup ===
 Installing individual tools: git, zsh
@@ -104,7 +104,7 @@ Installing oh-my-zsh...
 $ anvil init
 
 # Install essential applications
-$ anvil setup new-laptop
+$ anvil install new-laptop
 
 === Setting up 'new-laptop' group ===
 Installing tools for group 'new-laptop': slack, chrome, 1password
@@ -130,10 +130,10 @@ Successfully installed 3 of 3 tools in group 'new-laptop'
 $ anvil init
 
 # Install core development tools
-$ anvil setup dev
+$ anvil install dev
 
 # Add frontend-specific tools
-$ anvil setup chrome
+$ anvil install chrome
 
 # Verify installation
 $ git --version
@@ -157,7 +157,7 @@ groups:
 Then use it:
 
 ```bash
-$ anvil setup frontend
+$ anvil install frontend
 ```
 
 ### Example 5: Backend Developer Setup
@@ -169,7 +169,7 @@ $ anvil setup frontend
 $ anvil init
 
 # Install development tools
-$ anvil setup dev
+$ anvil install dev
 
 # Add Docker through custom group configuration
 # (See settings.yaml custom group setup)
@@ -193,7 +193,7 @@ groups:
 **Usage**:
 
 ```bash
-$ anvil setup backend
+$ anvil install backend
 ```
 
 ### Example 6: Full-Stack Developer Setup
@@ -205,13 +205,13 @@ $ anvil setup backend
 $ anvil init
 
 # Install all development tools
-$ anvil setup dev
+$ anvil install dev
 
 # Add communication tools
-$ anvil setup slack
+$ anvil install slack
 
 # Add browser for testing
-$ anvil setup chrome
+$ anvil install chrome
 
 # Optional: Add custom tools through group configuration
 # (See settings.yaml for custom group setup)
@@ -235,11 +235,11 @@ anvil init
 
 # Install core development tools
 echo "🔧 Installing development tools..."
-anvil setup dev
+anvil install dev
 
 # Install team communication tools
 echo "💬 Installing communication tools..."
-anvil setup slack
+anvil install slack
 
 # Install additional tools through custom groups
 echo "🔧 Installing additional tools..."
@@ -247,7 +247,7 @@ echo "🔧 Installing additional tools..."
 
 # Custom team tools
 echo "🛠️  Installing team-specific tools..."
-anvil setup --figma --postman
+anvil install --figma --postman
 
 echo "✅ Setup complete! Welcome to the team!"
 echo "📚 Next steps:"
@@ -319,7 +319,7 @@ cp anvil-config/team-settings.yaml ~/.anvil/settings.yaml
 curl -o ~/.anvil/settings.yaml https://company.com/anvil/team-settings.yaml
 
 # Then install team tools
-anvil setup frontend  # or backend, qa
+anvil install frontend  # or backend, qa
 ```
 
 ### Example 9: Multi-Platform Team Setup
@@ -330,8 +330,8 @@ anvil setup frontend  # or backend, qa
 
 ```bash
 anvil init
-anvil setup dev
-anvil setup --slack
+anvil install dev
+anvil install --slack
 ```
 
 **Linux team member**:
@@ -339,7 +339,7 @@ anvil setup --slack
 ```bash
 anvil init
 # May see platform warnings
-anvil setup --git --vscode
+anvil install --git --vscode
 # Install additional tools manually or via platform package manager
 ```
 
@@ -348,7 +348,7 @@ anvil setup --git --vscode
 ```bash
 # Use WSL or Git Bash
 anvil init
-anvil setup --git --vscode
+anvil install --git --vscode
 # Install Windows-specific alternatives manually
 ```
 
@@ -716,10 +716,10 @@ groups:
 
 ```bash
 # Install specific workflow tools
-anvil setup mobile
-anvil setup data-science
-anvil setup devops
-anvil setup design
+anvil install mobile
+anvil install data-science
+anvil install devops
+anvil install design
 ```
 
 ### Example 11: Environment-Specific Setup
@@ -730,7 +730,7 @@ anvil setup design
 
 ```bash
 anvil init
-anvil setup dev
+anvil install dev
 # Additional tools through custom groups
 ```
 
@@ -738,7 +738,7 @@ anvil setup dev
 
 ```bash
 anvil init
-anvil setup --git  # Minimal tools only
+anvil install --git  # Minimal tools only
 # Production-specific tools via other means
 ```
 
@@ -746,8 +746,8 @@ anvil setup --git  # Minimal tools only
 
 ```bash
 anvil init
-anvil setup --git --chrome
-anvil setup --cypress --postman
+anvil install --git --chrome
+anvil install --cypress --postman
 ```
 
 ### Example 12: Project-Specific Tool Installation
@@ -768,7 +768,7 @@ cat >> ~/.anvil/settings.yaml << EOF
       - react-devtools
 EOF
 
-anvil setup react-project
+anvil install react-project
 ```
 
 **Python Project**:
@@ -784,7 +784,7 @@ cat >> ~/.anvil/settings.yaml << EOF
       - jupyter
 EOF
 
-anvil setup python-project
+anvil install python-project
 ```
 
 ## Platform-Specific Examples
@@ -796,11 +796,11 @@ anvil setup python-project
 ```bash
 # Full macOS setup
 anvil init  # Installs Homebrew automatically
-anvil setup dev  # Includes iTerm2
-anvil setup new-laptop
+anvil install dev  # Includes iTerm2
+anvil install new-laptop
 
 # Add macOS-specific productivity tools
-anvil setup --alfred --spectacle --raycast
+anvil install --alfred --spectacle --raycast
 ```
 
 ### Example 14: Linux Development Setup
@@ -813,7 +813,7 @@ sudo apt update
 sudo apt install -y git curl build-essential
 
 anvil init
-anvil setup --git --vscode
+anvil install --git --vscode
 
 # Linux-specific additions
 sudo apt install -y zsh vim tmux
@@ -826,7 +826,7 @@ sudo apt install -y zsh vim tmux
 ```bash
 # In WSL
 anvil init
-anvil setup --git --vscode
+anvil install --git --vscode
 
 # Install Windows VS Code extension for WSL integration
 # Some tools need Windows-specific installation
@@ -840,13 +840,13 @@ anvil setup --git --vscode
 
 ```bash
 # Check what failed
-anvil setup dev
+anvil install dev
 
 # Output shows:
 # ❌ Failed to install vscode: package not found
 
 # Debug individual tool
-anvil setup --vscode --dry-run
+anvil install --vscode --dry-run
 
 # Check Homebrew
 brew update
@@ -888,7 +888,7 @@ sudo chown -R $(whoami) ~/.anvil
 chmod 755 ~/.anvil
 
 # Retry installation
-anvil setup dev
+anvil install dev
 ```
 
 ## Integration Examples
@@ -921,7 +921,7 @@ jobs:
         run: ./anvil init
 
       - name: Install Development Tools
-        run: ./anvil setup dev --dry-run # Dry run in CI
+        run: ./anvil install dev --dry-run # Dry run in CI
 ```
 
 ### Example 20: Docker Container with Anvil
@@ -963,7 +963,7 @@ docker build -t anvil-dev .
 docker run -it anvil-dev
 
 # Inside container
-anvil setup --git --vscode
+anvil install --git --vscode
 ```
 
 ### Example 21: Makefile Integration
@@ -978,14 +978,14 @@ anvil setup --git --vscode
 setup-dev:
 	@echo "Setting up development environment..."
 	anvil init
-	anvil setup dev
+	anvil install dev
 	@echo "Development setup complete!"
 
 setup-team:
 	@echo "Setting up team environment..."
 	anvil init
-	anvil setup dev
-	anvil setup --slack
+	anvil install dev
+	anvil install --slack
 	@echo "Team setup complete!"
 
 clean-anvil:
@@ -1048,36 +1048,36 @@ read -p "Enter your choice (1-6): " choice
 case $choice in
     1)
         echo "🎨 Setting up Frontend Development..."
-        anvil setup dev
-        anvil setup --chrome
+        anvil install dev
+        anvil install --chrome
         ;;
     2)
         echo "⚙️ Setting up Backend Development..."
-        anvil setup dev
+        anvil install dev
         # Additional tools through custom groups
         ;;
     3)
         echo "🔄 Setting up Full-Stack Development..."
-        anvil setup dev
-        anvil setup --chrome
+        anvil install dev
+        anvil install --chrome
         ;;
     4)
         echo "📱 Setting up Mobile Development..."
-        anvil setup --git --vscode
+        anvil install --git --vscode
         echo "Note: Install Xcode and Android Studio manually"
         ;;
     5)
         echo "📊 Setting up Data Science..."
-        anvil setup --git --vscode --python
+        anvil install --git --vscode --python
         ;;
     6)
         echo "🛠️ Custom tool selection..."
-        anvil setup --list
-        echo "Use 'anvil setup --tool1 --tool2' to install specific tools"
+        anvil install --list
+        echo "Use 'anvil install --tool1 --tool2' to install specific tools"
         ;;
     *)
         echo "Invalid choice. Running basic setup..."
-        anvil setup dev
+        anvil install dev
         ;;
 esac
 
@@ -1086,7 +1086,7 @@ echo "✅ Setup complete!"
 echo "📚 Next steps:"
 echo "  - Configure Git: git config --global user.name 'Your Name'"
 echo "  - Configure Git: git config --global user.email 'you@example.com'"
-echo "  - Check installed tools: anvil setup --list"
+echo "  - Check installed tools: anvil install --list"
 ```
 
 ### Example 23: Backup and Restore Configuration
@@ -1153,20 +1153,20 @@ fi
 
 ```bash
 # Basic setup
-anvil init && anvil setup dev
+anvil init && anvil install dev
 
 # Preview before install
-anvil setup dev --dry-run
+anvil install dev --dry-run
 
 # Individual tools
-anvil setup --git --zsh --vscode
+anvil install --git --zsh --vscode
 
 # List options
-anvil setup --list
+anvil install --list
 
 # Help
 anvil --help
-anvil setup --help
+anvil install --help
 ```
 
 ### Configuration Locations

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -25,7 +25,7 @@ Anvil is a CLI automation tool that helps developers:
 
 ### Key Concepts
 
-- **Commands**: Actions you can perform (`init`, `setup`, `config pull`, `config push`, `draw`)
+- **Commands**: Actions you can perform (`init`, `setup`, `config pull`, `config push`)
 - **Groups**: Collections of related tools (`dev`, `new-laptop`, custom groups)
 - **Configuration**: Settings stored in `~/.anvil/settings.yaml`
 - **Tools**: Individual applications or utilities that can be installed
@@ -90,7 +90,7 @@ anvil --help
 
 # Get help for specific commands
 anvil init --help
-anvil setup --help
+anvil install --help
 anvil config --help
 anvil config pull --help
 anvil config push --help
@@ -133,7 +133,7 @@ Anvil organizes tools into logical groups for easy batch installation:
 Install essential development tools:
 
 ```bash
-anvil setup dev
+anvil install dev
 ```
 
 This installs:
@@ -148,7 +148,7 @@ This installs:
 Set up a new machine with essential applications:
 
 ```bash
-anvil setup new-laptop
+anvil install new-laptop
 ```
 
 This installs:
@@ -162,8 +162,8 @@ This installs:
 Use dry-run to see what would be installed:
 
 ```bash
-anvil setup dev --dry-run
-anvil setup new-laptop --dry-run
+anvil install dev --dry-run
+anvil install new-laptop --dry-run
 ```
 
 ### Installing Individual Applications
@@ -172,14 +172,14 @@ Install any application by name with automatic tracking:
 
 ```bash
 # Install any application available through Homebrew
-anvil setup git
-anvil setup firefox
-anvil setup slack
-anvil setup visual-studio-code
-anvil setup figma
+anvil install git
+anvil install firefox
+anvil install slack
+anvil install visual-studio-code
+anvil install figma
 
 # Preview installation
-anvil setup firefox --dry-run
+anvil install firefox --dry-run
 ```
 
 **🎯 Automatic Tracking**: Individual apps are automatically added to `tools.installed_apps` in your settings.yaml.
@@ -196,7 +196,7 @@ anvil setup firefox --dry-run
 See all available groups and tools:
 
 ```bash
-anvil setup --list
+anvil install --list
 ```
 
 ## Common Workflows
@@ -210,10 +210,10 @@ Complete setup for a new development machine:
 anvil init
 
 # Step 2: Install development tools
-anvil setup dev
+anvil install dev
 
 # Step 3: Add essential applications
-anvil setup new-laptop
+anvil install new-laptop
 
 # Step 4: Add any additional tools as needed
 # (Additional tools can be installed through custom groups)
@@ -228,10 +228,10 @@ Quickly onboard a new team member:
 anvil init
 
 # Install team-standard tools
-anvil setup dev
+anvil install dev
 
 # Add team communication tools
-anvil setup slack
+anvil install slack
 
 # Additional tools can be defined in custom groups
 # See configuration section for custom group setup
@@ -246,10 +246,10 @@ Install only specific tools you need:
 anvil init
 
 # Preview what you want
-anvil setup dev --dry-run
+anvil install dev --dry-run
 
 # Install selected tools
-anvil setup dev
+anvil install dev
 ```
 
 ### Workflow 4: Custom Group Creation
@@ -277,8 +277,8 @@ groups:
 Then use your custom groups:
 
 ```bash
-anvil setup frontend
-anvil setup backend
+anvil install frontend
+anvil install backend
 ```
 
 ## Understanding Configuration
@@ -457,19 +457,19 @@ The `anvil config push` command is under development and will allow you to uploa
 1. **Use dry-run first** to preview installations:
 
    ```bash
-   anvil setup dev --dry-run
+   anvil install dev --dry-run
    ```
 
 2. **Start with groups**, then add individual tools:
 
    ```bash
-   anvil setup dev
-   anvil setup docker && anvil setup kubectl
+   anvil install dev
+   anvil install docker && anvil install kubectl
    ```
 
 3. **Check available options** before installing:
    ```bash
-   anvil setup --list
+   anvil install --list
    ```
 
 ### 📋 Configuration Best Practices
@@ -525,8 +525,8 @@ brew update
 ping -c 3 github.com
 
 # Try individual installation to isolate issues
-anvil setup git --dry-run
-anvil setup git
+anvil install git --dry-run
+anvil install git
 ```
 
 #### Configuration Issues
@@ -615,10 +615,10 @@ Now that you're familiar with the basics:
 
 ```bash
 anvil init                      # Initialize Anvil
-anvil setup --list            # List available groups and tools
-anvil setup dev                # Install development tools
-anvil setup git && anvil setup zsh  # Install specific tools individually
-anvil setup dev --dry-run     # Preview installations
+anvil install --list            # List available groups and tools
+anvil install dev                # Install development tools
+anvil install git && anvil install zsh  # Install specific tools individually
+anvil install dev --dry-run     # Preview installations
 anvil config pull cursor      # Pull Cursor configurations from remote
 anvil config pull vs-code     # Pull VS Code configurations from remote
 anvil config push cursor      # Push configurations to remote (coming soon)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -280,9 +280,8 @@ anvil --help
 
 # Verify main commands are available
 anvil init --help
-anvil setup --help
+anvil install --help
 anvil config --help
-anvil draw --help
 
 # Test initialization (this should work without errors)
 anvil init
@@ -295,10 +294,10 @@ anvil init
 anvil init
 
 # List available tools
-anvil setup --list
+anvil install --list
 
 # Test dry run
-anvil setup dev --dry-run
+anvil install dev --dry-run
 
 # Check configuration
 cat ~/.anvil/settings.yaml
@@ -309,8 +308,7 @@ cat ~/.anvil/settings.yaml
 ```bash
 # Verify all components
 anvil init
-anvil setup --list
-anvil draw "Test"
+anvil install --list
 
 # Check configuration directory
 ls -la ~/.anvil/

--- a/docs/init-readme.md
+++ b/docs/init-readme.md
@@ -169,7 +169,7 @@ These steps are optional but recommended for the best experience.
 
 You can now use:
   • 'anvil --help' to see all available commands
-  • 'anvil setup' to install development tools
+  • 'anvil install' to install development tools
   • 'anvil config pull' and 'anvil config push' to synchronize configuration files with GitHub
   • Edit ~/.anvil/settings.yaml to customize your configuration
 ```
@@ -225,11 +225,6 @@ The init command prepares your system for all other Anvil commands:
 - Depend on Git configuration validated during init
 - Use SSH keys whose presence is checked during initialization
 - Store configuration files in the main config directory
-
-### Draw Command
-
-- Uses terminal output formatting established during init
-- Integrates with the overall Anvil user experience
 
 ## Configuration Customization
 

--- a/docs/install-readme.md
+++ b/docs/install-readme.md
@@ -1,12 +1,12 @@
-# Anvil Setup Command Documentation
+# Anvil Install Command Documentation
 
 ## Overview
 
-The `anvil setup` command provides automated batch installation of development tools and applications using Homebrew (on macOS) or other package managers. This command is designed to streamline the process of setting up consistent development environments across different machines by organizing tools into logical groups.
+The `anvil install` command provides automated batch installation of development tools and applications using Homebrew (on macOS) or other package managers. This command is designed to streamline the process of setting up consistent development environments across different machines by organizing tools into logical groups.
 
 ## Purpose and Importance
 
-The setup command serves several critical functions:
+The install command serves several critical functions:
 
 - **Standardized Development Environments** - Ensures consistent tool configurations across team members and machines
 - **Automated Tool Installation** - Eliminates the tedious manual process of installing development tools one by one
@@ -21,7 +21,7 @@ The setup command serves several critical functions:
 Install all tools in a predefined group:
 
 ```bash
-anvil setup [group-name]
+anvil install [group-name]
 ```
 
 ### Individual Application Mode
@@ -29,9 +29,9 @@ anvil setup [group-name]
 Install any application by name with automatic tracking:
 
 ```bash
-anvil setup firefox
-anvil setup slack
-anvil setup figma
+anvil install firefox
+anvil install slack
+anvil install figma
 ```
 
 ### Utility Mode
@@ -39,15 +39,15 @@ anvil setup figma
 List available groups or perform dry runs:
 
 ```bash
-anvil setup --list
-anvil setup --dry-run
+anvil install --list
+anvil install --dry-run
 ```
 
 ## Available Groups
 
 ### Default Groups
 
-The setup command comes with two predefined groups:
+The install command comes with two predefined groups:
 
 #### 1. Development Group (`dev`)
 
@@ -62,7 +62,7 @@ The setup command comes with two predefined groups:
 **Usage**:
 
 ```bash
-anvil setup dev
+anvil install dev
 ```
 
 #### 2. New Laptop Group (`new-laptop`)
@@ -77,7 +77,7 @@ anvil setup dev
 **Usage**:
 
 ```bash
-anvil setup new-laptop
+anvil install new-laptop
 ```
 
 ### Custom Groups
@@ -102,11 +102,11 @@ groups:
 
 ### Dynamic Installation & Automatic Tracking
 
-The setup command supports installing **any macOS application** available through Homebrew by name. Individual apps are **automatically tracked** in your settings.yaml file.
+The install command supports installing **any macOS application** available through Homebrew by name. Individual apps are **automatically tracked** in your settings.yaml file.
 
 ### How It Works
 
-1. **Install any app by name**: `anvil setup [app-name]`
+1. **Install any app by name**: `anvil install [app-name]`
 2. **Automatic detection**: Checks if app is already installed
 3. **Smart tracking**: Adds to `tools.installed_apps` in settings.yaml
 4. **Duplicate prevention**: Won't track apps already in groups or required/optional tools
@@ -117,26 +117,26 @@ The setup command supports installing **any macOS application** available throug
 
 ```bash
 # Install any application by name (auto-tracked)
-anvil setup git
-anvil setup firefox
-anvil setup slack
-anvil setup visual-studio-code
-anvil setup figma
-anvil setup notion
-anvil setup spotify
+anvil install git
+anvil install firefox
+anvil install slack
+anvil install visual-studio-code
+anvil install figma
+anvil install notion
+anvil install spotify
 ```
 
 **Install with dry run to preview:**
 
 ```bash
-anvil setup firefox --dry-run
+anvil install firefox --dry-run
 ```
 
 **Register existing apps for tracking:**
 
 ```bash
 # Works on already-installed apps too
-anvil setup figma  # "figma is already installed" + adds to tracking
+anvil install figma  # "figma is already installed" + adds to tracking
 ```
 
 ### Automatic Tracking in settings.yaml
@@ -155,9 +155,9 @@ groups:
 
 **Smart Deduplication:**
 
-- ✅ `anvil setup figma` → tracked in `installed_apps`
-- ❌ `anvil setup git` → already in `required_tools`, not duplicated
-- ❌ `anvil setup dev` → group installation, individual apps not tracked separately
+- ✅ `anvil install figma` → tracked in `installed_apps`
+- ❌ `anvil install git` → already in `required_tools`, not duplicated
+- ❌ `anvil install dev` → group installation, individual apps not tracked separately
 
 ## Command Options and Flags
 
@@ -172,19 +172,19 @@ groups:
 **List all available groups:**
 
 ```bash
-anvil setup --list
+anvil install --list
 ```
 
 **Preview what would be installed:**
 
 ```bash
-anvil setup dev --dry-run
+anvil install dev --dry-run
 ```
 
 **Show help information:**
 
 ```bash
-anvil setup --help
+anvil install --help
 ```
 
 ## Tool Installation Details
@@ -295,7 +295,7 @@ Successfully installed 4 of 4 tools in group 'dev'
 
 ### settings.yaml Structure
 
-The setup command reads group configurations from `~/.anvil/settings.yaml`:
+The install command reads group configurations from `~/.anvil/settings.yaml`:
 
 ```yaml
 groups:
@@ -339,8 +339,8 @@ groups:
 After adding custom groups, they become available for installation:
 
 ```bash
-anvil setup data-science
-anvil setup mobile-dev
+anvil install data-science
+anvil install mobile-dev
 ```
 
 ## Platform Support
@@ -381,7 +381,7 @@ anvil setup mobile-dev
 
 ### Error Recovery
 
-The setup command continues installing other tools even if some fail:
+The install command continues installing other tools even if some fail:
 
 ```
 === Group Setup Complete! ===
@@ -394,7 +394,7 @@ Successfully installed 3 of 4 tools in group 'dev'
 
 ### Pre-Setup Checklist
 
-Before running setup commands:
+Before running install commands:
 
 - [ ] Ensure you have administrative privileges
 - [ ] Run `anvil init` to initialize your configuration
@@ -412,25 +412,25 @@ Before running setup commands:
 2. **Review available groups:**
 
    ```bash
-   anvil setup --list
+   anvil install --list
    ```
 
 3. **Test with dry run:**
 
    ```bash
-   anvil setup dev --dry-run
+   anvil install dev --dry-run
    ```
 
 4. **Install your desired group:**
 
    ```bash
-   anvil setup dev
+   anvil install dev
    ```
 
 5. **Add individual tools as needed:**
    ```bash
-   anvil setup slack
-   anvil setup chrome
+   anvil install slack
+   anvil install chrome
    ```
 
 ### Group Organization Strategy
@@ -458,10 +458,10 @@ Before running setup commands:
 anvil init
 
 # Install development tools
-anvil setup dev
+anvil install dev
 
 # Configure additional settings
-anvil setup git && anvil setup zsh
+anvil install git && anvil install zsh
 
 # Sync with GitHub (if applicable)
 anvil config pull
@@ -473,11 +473,11 @@ For tools not included in the predefined lists, you can:
 
 1. **Add to custom groups in settings.yaml**
 2. **Install directly via Homebrew integration**
-3. **Extend the setup command with custom installers**
+3. **Extend the install command with custom installers**
 
 ### Automation and Scripting
 
-The setup command is designed to be scriptable:
+The install command is designed to be scriptable:
 
 ```bash
 #!/bin/bash
@@ -485,8 +485,8 @@ The setup command is designed to be scriptable:
 
 echo "Setting up new development machine..."
 anvil init
-anvil setup new-laptop
-anvil setup dev
+anvil install new-laptop
+anvil install dev
 echo "Setup complete!"
 ```
 
@@ -590,7 +590,7 @@ brew install --cask visual-studio-code
 
 ### Extensibility
 
-The setup command is designed to be extensible:
+The install command is designed to be extensible:
 
 - New tools can be easily added to installation logic
 - Custom installers can be integrated
@@ -599,6 +599,6 @@ The setup command is designed to be extensible:
 
 ## Conclusion
 
-The `anvil setup` command provides a powerful and flexible way to install and manage development tools. Its group-based approach, combined with individual tool installation options, makes it suitable for both individual developers and teams. The command's integration with Anvil's configuration system ensures consistency across different environments while providing the flexibility needed for diverse development workflows.
+The `anvil install` command provides a powerful and flexible way to install and manage development tools. Its group-based approach, combined with individual tool installation options, makes it suitable for both individual developers and teams. The command's integration with Anvil's configuration system ensures consistency across different environments while providing the flexibility needed for diverse development workflows.
 
-Whether you're setting up a new development machine, onboarding team members, or maintaining consistent tool configurations, the setup command provides the automation and reliability needed for modern development environments.
+Whether you're setting up a new development machine, onboarding team members, or maintaining consistent tool configurations, the install command provides the automation and reliability needed for modern development environments.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,12 +18,12 @@ package constants
 
 // Command operation constants
 const (
-	OpInit   = "init"
-	OpSetup  = "setup"
-	OpConfig = "config"
-	OpPull   = "pull"
-	OpPush   = "push"
-	OpDraw   = "draw"
+	OpInit    = "init"
+	OpInstall = "install"
+	OpConfig  = "config"
+	OpPull    = "pull"
+	OpPush    = "push"
+	OpDraw    = "draw"
 )
 
 // System command constants

--- a/pkg/constants/descriptions.go
+++ b/pkg/constants/descriptions.go
@@ -21,61 +21,65 @@ const ANVIL_LONG_DESCRIPTION = `Anvil is a powerful macOS automation CLI tool de
 and personal tool configuration. It provides a comprehensive suite of commands for managing
 development environments, automating installations, and maintaining consistent configurations.
 
-Key features:
-- Automated tool installation via Homebrew
-- Dynamic group and individual app installation
-- Environment configuration management
-- ASCII art generation for enhanced terminal output
-- Optimized specifically for macOS`
+Key Features:
+• 🎯 Effortlessly install any macOS application using Homebrew
+• 📝 Automatically track individually installed apps in your settings.yaml
+• Organize tools with flexible group management for different workflows
+• ⚡ Zero configuration required: ready to use with smart defaults
+• 🍺 Seamless Homebrew integration for automated installation and updates
+• 🔍 Dry-run mode to preview changes before making them
+• Beautiful output with colored, structured progress indicators`
 
 const INIT_COMMAND_LONG_DESCRIPTION = `The init command bootstraps your Anvil CLI environment by performing a complete
 initialization process. This is the first command you should run after installing Anvil.
 
 What it does:
-• Validates and installs required system tools (Git, cURL, Homebrew)
+• ✅ Validates and installs required system tools (Git, cURL, Homebrew)
 • Creates necessary configuration directory (~/.anvil)
 • Generates a default settings.yaml configuration file with your system preferences
 • Checks your local environment for common development configurations
-• Provides actionable recommendations for completing your setup
+• 💡 Provides actionable recommendations for completing your setup
 
 This command is designed specifically for macOS and requires Homebrew for tool management.`
 
-const SETUP_COMMAND_LONG_DESCRIPTION = `The setup command provides dynamic installation of development tools and applications 
-using Homebrew on macOS.
+const INSTALL_COMMAND_LONG_DESCRIPTION = `The install command provides dynamic installation of development tools and applications
+for macOS using Homebrew. It supports both group-based and individual installations.
 
-Usage:
-• anvil setup [group-name]    - Install all tools in a predefined group
-• anvil setup [app-name]      - Install any individual application via brew
+Installation Modes:
+• anvil install [group-name]    - Install all tools in a predefined group
+• anvil install [app-name]      - Install any individual application via brew
 
-This command intelligently determines if the argument is a group name (defined in settings.yaml)
-or an application name. If it's not a group, it attempts to install the application directly
-using Homebrew. All installations are validated and errors are handled gracefully.
+Available Groups: 
+• dev - Essential development tools
+• new-laptop - Essential applications for new machines
+• Custom groups you define in settings.yaml
 
-🎯 Automatic App Tracking: Individual apps installed via 'anvil setup [app-name]' are 
-automatically tracked in your settings.yaml file. This creates a personal catalog of 
-installed applications, making it easy to recreate your setup on new machines.
+Special Features:
+• 📝 Automatic App Tracking: Individual apps installed via 'anvil install [app-name]' are
+  automatically tracked in your settings.yaml under tools.installed_apps, making it easy to
+  recreate your environment on new machines
+• Smart Deduplication: Apps in groups/required_tools are not tracked separately
+• 💡 Smart Discovery: Can't find an app? Get helpful suggestions for alternatives
 
-Supported groups: dev, new-laptop, and custom groups defined in your configuration.
+Use 'anvil install --list' to see all available groups and tracked apps.`
 
-Use 'anvil setup --list' to see all available groups and tracked apps.`
-
-const CONFIG_COMMAND_LONG_DESCRIPTION = `The config command provides centralized management of configuration files and assets
+const CONFIG_COMMAND_LONG_DESCRIPTION = `The config command provides centralized management of configuration files and dotfiles
 for your development environment. It serves as a parent command for pull and push operations
-to ensure all configuration-related actions are properly organized and guarded.
+to ensure all configuration-related actions are properly organized.
 
 Subcommands:
-• anvil config pull [directory]    - Pull configuration files from a specific directory in remote repository
+• anvil config pull [directory]    - Pull configuration files from remote repository
 • anvil config push [directory]    - Push configuration files to remote repository
 
 GitHub Repository Configuration:
 The 'github.config_repo' field in settings.yaml should be in the format 'username/repository'.
 
 Supported input formats (automatically corrected):
-  • username/repository (preferred format)
-  • https://github.com/username/repository
-  • https://github.com/username/repository.git
-  • git@github.com:username/repository.git  
-  • github.com/username/repository
+• username/repository (preferred format)
+• https://github.com/username/repository
+• https://github.com/username/repository.git
+• git@github.com:username/repository.git  
+• github.com/username/repository
 
 Example: 'github.config_repo: octocat/Hello-World'
 
@@ -83,30 +87,30 @@ This command structure ensures that all pull and push operations are scoped to c
 files only, providing clear separation between configuration management and other operations.
 Use this command to maintain consistent configuration across different development environments.`
 
-const PUSH_COMMAND_LONG_DESCRIPTION = `The push command enables you to upload and synchronize your local configuration files,
+const PUSH_COMMAND_LONG_DESCRIPTION = `The push command enables you to upload and synchronize your local configuration files
 and dotfiles to GitHub for backup and sharing purposes.
 
 Features:
 • Selective config pushing based on configuration
-• Automatic Git repository management
+• 🔄 Automatic Git repository management
 • Conflict resolution and merge handling
 • Support for various config types (dotfiles, configs, scripts)
 
 The command takes an argument to specify which type of configurations should be pushed,
 allowing for granular control over what gets synchronized to your remote repository.
-This command is now scoped to configuration files only.`
+This command is scoped to configuration files only for security and organization.`
 
 const PULL_COMMAND_LONG_DESCRIPTION = `The pull command allows you to download and synchronize configuration files
 from a specific directory in your GitHub repository to your local machine.
 
 Usage: anvil config pull [directory]
 
-The command automatically fetches the latest changes from your repository (git fetch/pull)
-and then copies all files from the specified directory to a temporary location 
-(~/.anvil/temp/[directory]) for review and application. You're guaranteed to get 
-the most up-to-date configurations every time.
+How it works:
+• 📥 Automatically fetches the latest changes from your repository (git fetch/pull)
+• Copies all files from the specified directory to a temporary location (~/.anvil/temp/[directory])
+• ✅ Guarantees you get the most up-to-date configurations every time
 
-This is particularly useful for:
+Perfect for:
 • Setting up new development environments
 • Synchronizing specific configurations across multiple machines
 • Restoring configurations after system changes
@@ -126,8 +130,7 @@ Supported formats include full URLs, SSH URLs, and domain-prefixed formats.
 Example: anvil config pull cursor    # Pulls all files from the 'cursor' directory`
 
 const DRAW_COMMAND_LONG_DESCRIPTION = `The draw command generates beautiful ASCII art representations of text using the
-go-figure library. This command enhances terminal output with visually appealing
-text formatting.
+go-figure library for enhanced terminal output and visual appeal.
 
 Features:
 • Multiple font options for different styles
@@ -135,5 +138,4 @@ Features:
 • Integration with Anvil's terminal output system
 • Support for various ASCII art styles
 
-This command is useful for creating distinctive headers, banners, or decorative
-elements in scripts and terminal applications.`
+Perfect for creating distinctive headers, banners, or decorative elements in scripts and terminal applications.`

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -41,22 +41,22 @@ func TestAnvilError_Error(t *testing.T) {
 		{
 			name: "platform error without command",
 			err: &AnvilError{
-				Op:   "setup",
+				Op:   "install",
 				Type: ErrorTypePlatform,
 				Err:  errors.New("unsupported platform"),
 			},
-			expected: "anvil setup [platform]: unsupported platform",
+			expected: "anvil install [platform]: unsupported platform",
 		},
 		{
 			name: "installation error with context",
 			err: &AnvilError{
-				Op:      "setup",
+				Op:      "install",
 				Command: "homebrew",
 				Type:    ErrorTypeInstallation,
 				Context: "brew install git",
 				Err:     errors.New("installation failed"),
 			},
-			expected: "anvil setup homebrew [installation] (brew install git): installation failed",
+			expected: "anvil install homebrew [installation] (brew install git): installation failed",
 		},
 		{
 			name: "configuration error with all fields",
@@ -101,13 +101,13 @@ func TestNewAnvilError(t *testing.T) {
 }
 
 func TestNewPlatformError(t *testing.T) {
-	err := NewPlatformError("setup", "install", fmt.Errorf("unsupported OS"))
+	err := NewPlatformError("install", "platform", fmt.Errorf("unsupported OS"))
 
 	if err.Type != ErrorTypePlatform {
 		t.Errorf("Expected Type to be ErrorTypePlatform, got %v", err.Type)
 	}
 
-	expected := "anvil setup install [platform]: unsupported OS"
+	expected := "anvil install platform [platform]: unsupported OS"
 	if err.Error() != expected {
 		t.Errorf("Expected error string to be '%s', got '%s'", expected, err.Error())
 	}
@@ -120,7 +120,7 @@ func TestErrorMatches(t *testing.T) {
 		t.Error("Expected ErrorMatches to return true for matching error")
 	}
 
-	if ErrorMatches(err, "setup", "validate", ErrorTypeValidation) {
+	if ErrorMatches(err, "install", "validate", ErrorTypeValidation) {
 		t.Error("Expected ErrorMatches to return false for different operation")
 	}
 
@@ -134,7 +134,7 @@ func TestErrorMatches(t *testing.T) {
 }
 
 func TestGetErrorType(t *testing.T) {
-	err := NewInstallationError("setup", "homebrew", fmt.Errorf("installation failed"))
+	err := NewInstallationError("install", "homebrew", fmt.Errorf("installation failed"))
 
 	if GetErrorType(err) != ErrorTypeInstallation {
 		t.Errorf("Expected GetErrorType to return ErrorTypeInstallation, got %v", GetErrorType(err))

--- a/pkg/installer/concurrent.go
+++ b/pkg/installer/concurrent.go
@@ -127,7 +127,7 @@ func (ci *ConcurrentInstaller) InstallTools(ctx context.Context, tools []string)
 
 	// Return error if any installations failed
 	if stats.FailedTools > 0 {
-		return stats, errors.NewInstallationError(constants.OpSetup, "concurrent",
+		return stats, errors.NewInstallationError(constants.OpInstall, "concurrent",
 			fmt.Errorf("failed to install %d of %d tools", stats.FailedTools, stats.TotalTools))
 	}
 
@@ -253,7 +253,7 @@ func (ci *ConcurrentInstaller) installSingleTool(ctx context.Context, tool strin
 
 	// Install the tool via brew
 	if err := brew.InstallPackage(tool); err != nil {
-		return fmt.Errorf("failed to install %s: %w", tool, err)
+		return errors.NewInstallationError(constants.OpInstall, tool, err)
 	}
 
 	// Handle post-install script if configured


### PR DESCRIPTION
- Rename setup→install command across entire codebase (files, functions, constants)
- Update all documentation files (README, docs/*.md) with new command syntax
- Remove obsolete draw command references from documentation
- Enhance command descriptions with consistent formatting and selective emoji usage
- Maintain backward compatibility for configuration files