### PR TITLE
feat: add config show command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Sync dotfiles and configurations across machines using GitHub repositories:
 anvil config pull cursor
 anvil config pull vs-code
 
+# View configurations
+anvil config show        # View anvil settings
+anvil config show cursor # View pulled configs
+
 # Push configurations (coming soon)
 anvil config push cursor
 ```
@@ -132,6 +136,7 @@ github:
 | `install [group]`   | Install tool group     | `anvil install dev`        |
 | `install --list`    | List available groups  | `anvil install --list`     |
 | `config pull [dir]` | Pull configurations    | `anvil config pull cursor` |
+| `config show [dir]` | Show configurations    | `anvil config show cursor` |
 | `config push [dir]` | Push configurations    | `anvil config push cursor` |
 
 ### Useful Flags

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"github.com/rocajuanma/anvil/cmd/config/pull"
 	"github.com/rocajuanma/anvil/cmd/config/push"
+	"github.com/rocajuanma/anvil/cmd/config/show"
 	"github.com/rocajuanma/anvil/pkg/constants"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,8 @@ var ConfigCmd = &cobra.Command{
 }
 
 func init() {
-	// Add pull and push as sub-commands of config
+	// Add pull, push, and show as sub-commands of config
 	ConfigCmd.AddCommand(pull.PullCmd)
 	ConfigCmd.AddCommand(push.PushCmd)
+	ConfigCmd.AddCommand(show.ShowCmd)
 }

--- a/cmd/config/show/show.go
+++ b/cmd/config/show/show.go
@@ -1,0 +1,319 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package show
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/rocajuanma/anvil/pkg/config"
+	"github.com/rocajuanma/anvil/pkg/constants"
+	"github.com/rocajuanma/anvil/pkg/errors"
+	"github.com/rocajuanma/anvil/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+var ShowCmd = &cobra.Command{
+	Use:   "show [directory]",
+	Short: "Show configuration files from anvil settings or pulled directories",
+	Long:  constants.SHOW_COMMAND_LONG_DESCRIPTION,
+	Args:  cobra.MaximumNArgs(1), // Accept 0 or 1 argument
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runShowCommand(cmd, args); err != nil {
+			terminal.PrintError("Show failed: %v", err)
+			return
+		}
+	},
+}
+
+// runShowCommand executes the configuration show process
+func runShowCommand(cmd *cobra.Command, args []string) error {
+	// If no arguments provided, show the anvil settings.yaml
+	if len(args) == 0 {
+		return showAnvilSettings()
+	}
+
+	// Show specific pulled configuration directory
+	targetDir := args[0]
+	return showPulledConfig(targetDir)
+}
+
+// showAnvilSettings displays the main anvil settings.yaml file
+func showAnvilSettings() error {
+	configPath := config.GetConfigPath()
+
+	// Check if settings file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		terminal.PrintError("Anvil settings file not found at: %s", configPath)
+		terminal.PrintInfo("💡 Run 'anvil init' to create the initial settings file")
+		return fmt.Errorf("settings file not found")
+	}
+
+	terminal.PrintHeader("Anvil Settings Configuration")
+	terminal.PrintInfo("File: %s", configPath)
+	terminal.PrintInfo("")
+
+	// Read and display the file content
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return errors.NewFileSystemError(constants.OpShow, "read-settings", err)
+	}
+
+	fmt.Print(string(content))
+	return nil
+}
+
+// showPulledConfig displays configuration files from a pulled directory
+func showPulledConfig(targetDir string) error {
+	// Get config directory
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return errors.NewConfigurationError(constants.OpShow, "load-config", err)
+	}
+
+	// Build path to the pulled config directory
+	tempDir := filepath.Join(cfg.Directories.Config, "temp", targetDir)
+
+	// Check if the directory exists
+	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		terminal.PrintError("Configuration directory '%s' not found", targetDir)
+		terminal.PrintInfo("")
+		terminal.PrintInfo("💡 This could be because:")
+		terminal.PrintInfo("   • The app name is incorrect")
+		terminal.PrintInfo("   • The configuration was never pulled")
+		terminal.PrintInfo("   • The directory name doesn't match what was pulled")
+		terminal.PrintInfo("")
+		terminal.PrintInfo("🔧 To fix this:")
+		terminal.PrintInfo("   • Run 'anvil config pull %s' to download the configuration", targetDir)
+		terminal.PrintInfo("   • Check available pulled configs in: %s", filepath.Join(cfg.Directories.Config, "temp"))
+		return fmt.Errorf("configuration directory not found")
+	}
+
+	// Build and display the tree structure
+	return showDirectoryTree(tempDir, targetDir)
+}
+
+// TreeNode represents a node in the file tree
+type TreeNode struct {
+	Name     string
+	Path     string
+	IsDir    bool
+	Children []*TreeNode
+}
+
+// showDirectoryTree displays a tree structure of files/directories
+func showDirectoryTree(basePath, targetDir string) error {
+	// Build the tree structure
+	root, err := buildTree(basePath)
+	if err != nil {
+		return errors.NewFileSystemError(constants.OpShow, "build-tree", err)
+	}
+
+	// If there's only one file at root level, display its content directly
+	if len(root.Children) == 1 && !root.Children[0].IsDir {
+		return showSingleFile(root.Children[0].Path, targetDir)
+	}
+
+	terminal.PrintHeader(fmt.Sprintf("Configuration Directory: %s", targetDir))
+	terminal.PrintInfo("Path: %s", basePath)
+	terminal.PrintInfo("")
+
+	// Display the tree structure
+	terminal.PrintInfo("Directory structure:")
+	terminal.PrintInfo("")
+
+	// Sort children for consistent display
+	sortChildren(root)
+
+	// Print the tree starting from root
+	printTreeNode(root, "", true, true)
+
+	terminal.PrintInfo("")
+	terminal.PrintInfo("💡 To view a specific file, you can use:")
+	terminal.PrintInfo("   • cat %s/[filename]", basePath)
+	terminal.PrintInfo("   • Or navigate to the directory and explore manually")
+
+	return nil
+}
+
+// buildTree recursively builds a tree structure from the filesystem
+func buildTree(dirPath string) (*TreeNode, error) {
+	root := &TreeNode{
+		Name:     filepath.Base(dirPath),
+		Path:     dirPath,
+		IsDir:    true,
+		Children: []*TreeNode{},
+	}
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip the root directory itself
+		if path == dirPath {
+			return nil
+		}
+
+		// Get relative path from root
+		relPath, err := filepath.Rel(dirPath, path)
+		if err != nil {
+			return err
+		}
+
+		// Split the path into components
+		parts := strings.Split(relPath, string(filepath.Separator))
+
+		// Find or create the parent node
+		current := root
+		for i, part := range parts[:len(parts)-1] {
+			found := false
+			for _, child := range current.Children {
+				if child.Name == part && child.IsDir {
+					current = child
+					found = true
+					break
+				}
+			}
+			if !found {
+				// Create intermediate directory
+				newDir := &TreeNode{
+					Name:     part,
+					Path:     filepath.Join(dirPath, strings.Join(parts[:i+1], string(filepath.Separator))),
+					IsDir:    true,
+					Children: []*TreeNode{},
+				}
+				current.Children = append(current.Children, newDir)
+				current = newDir
+			}
+		}
+
+		// Add the final node
+		finalNode := &TreeNode{
+			Name:  parts[len(parts)-1],
+			Path:  path,
+			IsDir: info.IsDir(),
+		}
+		if info.IsDir() {
+			finalNode.Children = []*TreeNode{}
+		}
+		current.Children = append(current.Children, finalNode)
+
+		return nil
+	})
+
+	return root, err
+}
+
+// sortChildren recursively sorts all children in the tree (directories first, then files, both alphabetically)
+func sortChildren(node *TreeNode) {
+	if node.Children == nil {
+		return
+	}
+
+	// Sort children: directories first, then files, both alphabetically
+	sort.Slice(node.Children, func(i, j int) bool {
+		if node.Children[i].IsDir != node.Children[j].IsDir {
+			return node.Children[i].IsDir // directories come first
+		}
+		return node.Children[i].Name < node.Children[j].Name
+	})
+
+	// Recursively sort children
+	for _, child := range node.Children {
+		sortChildren(child)
+	}
+}
+
+// printTreeNode prints a tree node with ASCII art and colors
+func printTreeNode(node *TreeNode, prefix string, isLast bool, isRoot bool) {
+	if !isRoot {
+		// Choose the appropriate tree character
+		var treeChar string
+		if isLast {
+			treeChar = "└── "
+		} else {
+			treeChar = "├── "
+		}
+
+		// Color the output based on file type
+		var coloredName string
+		if node.IsDir {
+			coloredName = fmt.Sprintf("%s%s%s%s", terminal.ColorBold, terminal.ColorBlue, node.Name, terminal.ColorReset)
+		} else {
+			// Color files based on extension
+			ext := strings.ToLower(filepath.Ext(node.Name))
+			switch ext {
+			case ".json", ".yaml", ".yml", ".toml":
+				coloredName = fmt.Sprintf("%s%s%s", terminal.ColorGreen, node.Name, terminal.ColorReset)
+			case ".md", ".txt", ".log":
+				coloredName = fmt.Sprintf("%s%s%s", terminal.ColorCyan, node.Name, terminal.ColorReset)
+			case ".sh", ".zsh", ".bash":
+				coloredName = fmt.Sprintf("%s%s%s", terminal.ColorYellow, node.Name, terminal.ColorReset)
+			default:
+				coloredName = node.Name
+			}
+		}
+
+		// Print the current node
+		fmt.Printf("%s%s%s\n", prefix, treeChar, coloredName)
+	}
+
+	// Print children
+	if node.Children != nil {
+		for i, child := range node.Children {
+			isChildLast := i == len(node.Children)-1
+
+			// Calculate prefix for child
+			var childPrefix string
+			if isRoot {
+				childPrefix = ""
+			} else {
+				if isLast {
+					childPrefix = prefix + "    "
+				} else {
+					childPrefix = prefix + "│   "
+				}
+			}
+
+			printTreeNode(child, childPrefix, isChildLast, false)
+		}
+	}
+}
+
+// showSingleFile displays the content of a single configuration file
+func showSingleFile(filePath, targetDir string) error {
+	terminal.PrintHeader(fmt.Sprintf("Configuration: %s", targetDir))
+	terminal.PrintInfo("File: %s", filepath.Base(filePath))
+	terminal.PrintInfo("")
+
+	// Read and display the file content
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return errors.NewFileSystemError(constants.OpShow, "read-config-file", err)
+	}
+
+	fmt.Print(string(content))
+	return nil
+}
+
+func init() {
+	// Add any flags if needed in the future
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smart Duplicate Prevention** - Prevents tracking apps already in groups, required_tools, or optional_tools
 - **Dynamic Individual Installation** - Install any Homebrew package by name with automatic tracking
 - **Configuration Pull System** - Complete implementation of `anvil config pull [directory]` command
+- **Configuration Show System** - New `anvil config show [directory]` command to view pulled configs and settings
   - Directory-specific configuration pulling from GitHub repositories
   - SSH key and GitHub token authentication support
   - Automatic GitHub URL format validation and normalization

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -486,6 +486,10 @@ cp ~/.anvil/temp/cursor/keybindings.json ~/Library/Application\ Support/Cursor/U
 # 5. Pull other configurations as needed
 anvil config pull vs-code
 anvil config pull zsh
+
+# 6. Review configurations before applying
+anvil config show vs-code
+anvil config show zsh
 ```
 
 #### Current vs. Future Implementation

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -25,7 +25,7 @@ Anvil is a CLI automation tool that helps developers:
 
 ### Key Concepts
 
-- **Commands**: Actions you can perform (`init`, `setup`, `config pull`, `config push`)
+- **Commands**: Actions you can perform (`init`, `install`, `config pull`, `config show`, `config push`)
 - **Groups**: Collections of related tools (`dev`, `new-laptop`, custom groups)
 - **Configuration**: Settings stored in `~/.anvil/settings.yaml`
 - **Tools**: Individual applications or utilities that can be installed
@@ -93,6 +93,7 @@ anvil init --help
 anvil install --help
 anvil config --help
 anvil config pull --help
+anvil config show --help
 anvil config push --help
 ```
 
@@ -395,6 +396,10 @@ anvil config pull vs-code
 
 # Pull shell configurations
 anvil config pull zsh
+
+# View pulled configurations
+anvil config show cursor
+anvil config show vs-code
 ```
 
 **Current Behavior**: Always fetches the latest changes from your repository and pulls files to `~/.anvil/temp/[directory]` for review before manual application.
@@ -621,6 +626,8 @@ anvil install git && anvil install zsh  # Install specific tools individually
 anvil install dev --dry-run     # Preview installations
 anvil config pull cursor      # Pull Cursor configurations from remote
 anvil config pull vs-code     # Pull VS Code configurations from remote
+anvil config show cursor      # View pulled Cursor configurations
+anvil config show            # View anvil settings.yaml
 anvil config push cursor      # Push configurations to remote (coming soon)
 anvil --help                   # Get help
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -282,6 +282,7 @@ anvil --help
 anvil init --help
 anvil install --help
 anvil config --help
+anvil config show --help
 
 # Test initialization (this should work without errors)
 anvil init

--- a/docs/config-readme.md
+++ b/docs/config-readme.md
@@ -82,6 +82,10 @@ echo 'export GITHUB_TOKEN="your_token_here"' >> ~/.zshrc
 anvil config pull cursor
 anvil config pull vs-code
 anvil config pull zsh
+
+# View pulled configurations
+anvil config show cursor
+anvil config show vs-code
 ```
 
 ## 🔧 Configuration Setup
@@ -149,6 +153,16 @@ github.com/username/repository
 ## 📥 Pull Command
 
 ### Basic Usage
+
+### Configuration Commands
+
+The config command provides three main operations:
+
+- **`anvil config pull [directory]`** - Downloads configuration files from your GitHub repository
+- **`anvil config show [directory]`** - Views configuration files (anvil settings or pulled configs)
+- **`anvil config push [directory]`** - Uploads configuration files to your GitHub repository (coming soon)
+
+#### Pull Command
 
 The `anvil config pull` command downloads configuration files from your GitHub repository:
 
@@ -220,6 +234,7 @@ Copied files:
 
 Next steps:
   • Review the pulled configuration files in: /Users/username/.anvil/temp/cursor
+  • Use 'anvil config show [directory]' to view configuration content
   • Apply/copy configurations to their destination as needed
   • Use 'anvil config push' to upload any local changes
 ```
@@ -277,6 +292,42 @@ Anvil supports multiple authentication methods:
 3. **Public Repository Access**
    - No authentication required
    - Automatically falls back to HTTPS
+
+## 📄 Show Command
+
+### View Configuration Files
+
+The `anvil config show` command displays configuration files for easy viewing and inspection:
+
+```bash
+# View main anvil settings
+anvil config show
+
+# View pulled configuration directory
+anvil config show [directory]
+```
+
+### Features
+
+- **Single File Display**: Shows file content directly in terminal
+- **Multiple Files**: Shows tree structure with file listings
+- **Smart Detection**: Automatically determines best display method
+- **Helpful Errors**: Clear messages for missing directories with suggestions
+
+### Examples
+
+```bash
+# View your anvil settings.yaml
+anvil config show
+
+# View pulled Cursor configurations
+anvil config show cursor
+
+# View pulled VS Code configurations
+anvil config show vs-code
+```
+
+Perfect for reviewing pulled configurations before applying them or checking your current anvil settings.
 
 ## 📤 Push Command
 

--- a/docs/init-readme.md
+++ b/docs/init-readme.md
@@ -170,7 +170,7 @@ These steps are optional but recommended for the best experience.
 You can now use:
   • 'anvil --help' to see all available commands
   • 'anvil install' to install development tools
-  • 'anvil config pull' and 'anvil config push' to synchronize configuration files with GitHub
+  • 'anvil config pull', 'anvil config show', and 'anvil config push' to manage configuration files with GitHub
   • Edit ~/.anvil/settings.yaml to customize your configuration
 ```
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -23,6 +23,7 @@ const (
 	OpConfig  = "config"
 	OpPull    = "pull"
 	OpPush    = "push"
+	OpShow    = "show"
 	OpDraw    = "draw"
 )
 

--- a/pkg/constants/descriptions.go
+++ b/pkg/constants/descriptions.go
@@ -70,6 +70,7 @@ to ensure all configuration-related actions are properly organized.
 Subcommands:
 • anvil config pull [directory]    - Pull configuration files from remote repository
 • anvil config push [directory]    - Push configuration files to remote repository
+• anvil config show [directory]    - Show configuration files from anvil settings or pulled directories
 
 GitHub Repository Configuration:
 The 'github.config_repo' field in settings.yaml should be in the format 'username/repository'.
@@ -128,6 +129,20 @@ The repository URL format is automatically validated and corrected if needed.
 Supported formats include full URLs, SSH URLs, and domain-prefixed formats.
 
 Example: anvil config pull cursor    # Pulls all files from the 'cursor' directory`
+
+const SHOW_COMMAND_LONG_DESCRIPTION = `The show command displays configuration files and settings for easy viewing and inspection.
+
+Usage Modes:
+• anvil config show              - Display the main anvil settings.yaml file
+• anvil config show [directory]  - Show configuration files from a pulled directory
+
+Features:
+• 📄 Single file display: Shows file content directly in terminal
+• 📁 Multiple files: Shows tree structure with file listings
+• ✅ Smart file detection: Automatically determines best display method
+• 💡 Helpful error messages with suggestions for missing directories
+
+Perfect for reviewing pulled configurations before applying them or checking your current anvil settings.`
 
 const DRAW_COMMAND_LONG_DESCRIPTION = `The draw command generates beautiful ASCII art representations of text using the
 go-figure library for enhanced terminal output and visual appeal.


### PR DESCRIPTION
New Features:
- Add 'anvil config show' subcommand for viewing configuration files
- Support two modes: show anvil settings.yaml or pulled config directories
- Smart file detection: single files display content, multiple files show tree
- ASCII tree structure with proper indentation and visual hierarchy
- Color-coded files by type: directories (blue), configs (green), docs (cyan), scripts (yellow)

 File Structure:
- cmd/config/show/show.go - Complete show command implementation
- pkg/constants/constants.go - Add OpShow operation constant
- pkg/constants/descriptions.go - Add SHOW_COMMAND_LONG_DESCRIPTION
- cmd/config/config.go - Register show subcommand

Tree Display Improvements:
- Replace emoji-based display with ASCII characters (├──, └──, │)
- Implement proper tree traversal and node structure
- Sort directories first, then files (alphabetically)
- Color coding based on file extensions for better readability
- Professional terminal-friendly appearance

Documentation Updates:
- README.md - Add show command to usage examples and reference table
- docs/GETTING_STARTED.md - Include show in help commands and workflows
- docs/config-readme.md - Complete show command documentation section
- docs/EXAMPLES.md - Add show command to workflow examples
- docs/INSTALLATION.md - Include in command verification
- docs/CHANGELOG.md - Document new feature
- docs/init-readme.md - Update config commands summary

Technical Details:
- TreeNode structure for hierarchical file representation
- Recursive tree building with proper parent-child relationships
- Error handling for missing directories with helpful suggestions
- Consistent with existing codebase patterns and styling
- Full integration with terminal color system

Testing:
- Single file display functionality verified
- Multi-file tree structure display confirmed
- Error handling for non-existent directories tested
- All command help text updated and functional