### PR TITLE
feat(doctor): enhance git-config --fix to handle typos and regenerate values

### DIFF
--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -219,7 +219,7 @@ func runFixCheck(engine *validators.DoctorEngine, checkName string) error {
 	result := engine.RunCheck(ctx, checkName)
 	displayResults([]*validators.ValidationResult{result}, false)
 
-	if result.Status == validators.PASS {
+	if result.Status == validators.PASS && checkName != "git-config" {
 		terminal.PrintSuccess("Check is already passing, no fix needed")
 		return nil
 	}


### PR DESCRIPTION
* **Enhanced PopulateGitConfigFromSystem function:**
  - Always regenerates username/email from local git config
  - Auto-detects SSH keys from common locations with priority order
  - Supports id_ed25519, id_ed25519_personal, id_rsa, id_rsa_personal, id_ecdsa
  - Smart fallback to default path if no keys found

* **Completely rewritten GitConfigValidator.Fix() method:**
  - Always regenerates ALL git configuration values
  - Handles typos, invalid paths, and incorrect values by overriding
  - Provides detailed feedback showing before/after changes
  - Works regardless of current validation status

* **Updated validation behavior:**
  - Always shows AutoFix as available for git-config
  - Allows fix to run even when validation passes
  - Better messaging about regeneration capability

* **Key improvements:**
  - Fixes false-positives where validation passes but values are incorrect
  - No longer conservative - assumes at least one value needs correction
  - Comprehensive SSH key path detection and correction
  - Enhanced user experience with detailed change reporting

**Breaking Change:** git-config --fix now ALWAYS regenerates values from local git config, potentially overriding existing correct values. This is intentional to ensure all values are consistent with local system config.

**Usage:** anvil doctor git-config --fix
**Tested:** Multiple scenarios including typos, invalid paths, missing values