### PR TITLE
feat[settings]: simplify settings structure & complexity

### DIFF
--- a/cmd/config/pull/pull.go
+++ b/cmd/config/pull/pull.go
@@ -228,7 +228,7 @@ func copyDirectoryToTemp(cfg *config.AnvilConfig, targetDir string) (string, err
 	}
 
 	// Create temp directory inside anvil config
-	tempBasedir := filepath.Join(cfg.Directories.Config, "temp")
+	tempBasedir := filepath.Join(config.GetConfigDirectory(), "temp")
 	if err := os.MkdirAll(tempBasedir, constants.DirPerm); err != nil {
 		return "", errors.NewFileSystemError(constants.OpPull, "create-temp-dir", err)
 	}

--- a/cmd/config/show/show.go
+++ b/cmd/config/show/show.go
@@ -93,15 +93,11 @@ func showPulledConfig(targetDir string) error {
 
 	// Stage 1: Load anvil configuration
 	terminal.PrintStage("Loading anvil configuration...")
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return errors.NewConfigurationError(constants.OpShow, "load-config", err)
-	}
 	terminal.PrintSuccess("Configuration loaded")
 
 	// Stage 2: Locate pulled configuration directory
 	terminal.PrintStage("Locating pulled configuration directory...")
-	tempDir := filepath.Join(cfg.Directories.Config, "temp", targetDir)
+	tempDir := filepath.Join(config.GetConfigDirectory(), "temp", targetDir)
 
 	// Check if the directory exists
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
@@ -114,7 +110,7 @@ func showPulledConfig(targetDir string) error {
 		terminal.PrintInfo("")
 
 		// Show available pulled configurations
-		tempBasePath := filepath.Join(cfg.Directories.Config, "temp")
+		tempBasePath := filepath.Join(config.GetConfigDirectory(), "temp")
 		if entries, err := os.ReadDir(tempBasePath); err == nil && len(entries) > 0 {
 			terminal.PrintInfo("Available pulled configurations:")
 			for _, entry := range entries {
@@ -136,7 +132,7 @@ func showPulledConfig(targetDir string) error {
 
 	// Stage 3: Display directory contents
 	terminal.PrintStage("Reading configuration files...")
-	err = showDirectoryTree(tempDir, targetDir)
+	err := showDirectoryTree(tempDir, targetDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/config/sync/sync.go
+++ b/cmd/config/sync/sync.go
@@ -62,14 +62,8 @@ func runSyncCommand(cmd *cobra.Command, args []string) error {
 func syncAnvilSettings(dryRun bool) error {
 	terminal.PrintHeader("Configuration Sync: anvil settings")
 
-	// Load current config to get temp directory
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return errors.NewConfigurationError(constants.OpSync, "load-config", err)
-	}
-
 	// Check if pulled anvil settings exist
-	tempSettingsPath := filepath.Join(cfg.Directories.Config, "temp", "anvil", "settings.yaml")
+	tempSettingsPath := filepath.Join(config.GetConfigDirectory(), "temp", "anvil", "settings.yaml")
 	if _, err := os.Stat(tempSettingsPath); os.IsNotExist(err) {
 		terminal.PrintError("Pulled anvil settings not found")
 		terminal.PrintInfo("")
@@ -139,7 +133,7 @@ func syncAppConfig(appName string, dryRun bool) error {
 	}
 
 	// Check if pulled app config exists
-	tempAppPath := filepath.Join(cfg.Directories.Config, "temp", appName)
+	tempAppPath := filepath.Join(config.GetConfigDirectory(), "temp", appName)
 	if _, err := os.Stat(tempAppPath); os.IsNotExist(err) {
 		terminal.PrintError("Pulled %s configuration not found", appName)
 		terminal.PrintInfo("")
@@ -220,16 +214,11 @@ func syncAppConfig(appName string, dryRun bool) error {
 
 // createArchiveDirectory creates a timestamped archive directory
 func createArchiveDirectory(prefix string) (string, error) {
-	// Load config to get base directory
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return "", err
-	}
 
 	// Create timestamp
 	timestamp := time.Now().Format("2006-01-02-15-04-05")
 	archiveName := fmt.Sprintf("%s-%s", prefix, timestamp)
-	archivePath := filepath.Join(cfg.Directories.Config, "archive", archiveName)
+	archivePath := filepath.Join(config.GetConfigDirectory(), "archive", archiveName)
 
 	// Create archive directory
 	if err := os.MkdirAll(archivePath, constants.DirPerm); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,7 +38,6 @@ func setupTestConfig(t *testing.T) (string, func()) {
 
 	// Create a test config
 	config := GetDefaultConfig()
-	config.Directories.Config = tempDir
 
 	// Create the necessary directories
 	err := CreateDirectories()

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -110,11 +110,6 @@ func (cv *ConfigValidator) ValidateConfig(config interface{}) error {
 		return fmt.Errorf("version validation failed: %w", err)
 	}
 
-	// Validate directories
-	if err := cv.validateDirectories(&anvilConfig.Directories); err != nil {
-		return fmt.Errorf("directory validation failed: %w", err)
-	}
-
 	// Validate tools
 	if err := cv.validateTools(&anvilConfig.Tools); err != nil {
 		return fmt.Errorf("tools validation failed: %w", err)
@@ -147,20 +142,6 @@ func (cv *ConfigValidator) validateVersion(version string) error {
 	// Check semantic version format
 	if matched, _ := regexp.MatchString(`^\d+\.\d+\.\d+$`, version); !matched {
 		return fmt.Errorf("version '%s' is not in valid semantic version format (e.g., 1.0.0)", version)
-	}
-
-	return nil
-}
-
-// validateDirectories validates directory configurations
-func (cv *ConfigValidator) validateDirectories(dirs *AnvilDirectories) error {
-	if dirs.Config == "" {
-		return fmt.Errorf("config directory cannot be empty")
-	}
-
-	// Check if directory is an absolute path
-	if !filepath.IsAbs(dirs.Config) {
-		return fmt.Errorf("config directory must be an absolute path: %s", dirs.Config)
 	}
 
 	return nil

--- a/pkg/validators/environment.go
+++ b/pkg/validators/environment.go
@@ -166,10 +166,7 @@ func (v *DirectoryStructureValidator) Description() string {
 func (v *DirectoryStructureValidator) CanFix() bool { return true }
 
 func (v *DirectoryStructureValidator) Validate(ctx context.Context, cfg *config.AnvilConfig) *ValidationResult {
-	anvilDir := cfg.Directories.Config
-	if anvilDir == "" {
-		anvilDir = filepath.Join(os.Getenv("HOME"), ".anvil")
-	}
+	anvilDir := config.GetConfigDirectory()
 
 	// Required directories
 	requiredDirs := []string{
@@ -226,10 +223,7 @@ func (v *DirectoryStructureValidator) Validate(ctx context.Context, cfg *config.
 }
 
 func (v *DirectoryStructureValidator) Fix(ctx context.Context, cfg *config.AnvilConfig) error {
-	anvilDir := cfg.Directories.Config
-	if anvilDir == "" {
-		anvilDir = filepath.Join(os.Getenv("HOME"), ".anvil")
-	}
+	anvilDir := config.GetConfigDirectory()
 
 	// Create required directories
 	requiredDirs := []string{


### PR DESCRIPTION
Remove configurable directories section and hardcode .anvil path to reduce complexity while maintaining all functionality.

### Changes
- Removed AnvilDirectories struct and Directories field from config
- Hardcoded all directory references to use ~/.anvil via GetConfigDirectory()
- Updated all commands to use simplified path resolution
- Removed directory validation logic because that section was removed from settings