### PR TITLE
feat(install): add --group-name flag for automatic group assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ anvil install visual-studio-code
 anvil install dev        # git, zsh, iterm2, visual-studio-code
 anvil install new-laptop # slack, google-chrome, 1password
 
+# Install and organize into groups
+anvil install firefox --group-name browsers
+anvil install final-cut --group-name editing
+
 # Preview before installing
 anvil install docker --dry-run
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Group Assignment for Individual App Installation** 📦 - New `--group-name` flag for the `anvil install` command
+  - **Seamless Group Organization** - Install apps and automatically add them to existing or new groups
+  - **Dynamic Group Creation** - Creates new groups automatically if they don't exist
+  - **Duplicate Prevention** - Prevents adding the same app multiple times to a group
+  - **Graceful Fallback** - Falls back to normal `installed_apps` tracking if group operations fail
+  - **Success-Only Operations** - Group operations only occur if installation is successful
+  - **Usage Examples**: `anvil install firefox --group-name essentials`, `anvil install final-cut --group-name editing`
 - **Real-time Progress for Doctor Command** ✨ - Enhanced `anvil doctor` command with live feedback
   - **Live Progress Indicators** - See validation progress as each check runs with progress counters (e.g., `[1/12] 8% - Running init-run`)
   - **Stage-by-stage Feedback** - Clear indication of which validation is currently executing

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -135,6 +135,58 @@ Installing tools for group 'new-laptop': slack, chrome, 1password
 Successfully installed 3 of 3 tools in group 'new-laptop'
 ```
 
+### Example 3.5: Organizing Applications into Groups
+
+**Scenario**: Installing applications and organizing them into logical groups for better management.
+
+```bash
+# Initialize first
+$ anvil init
+
+# Install and organize browsers
+$ anvil install firefox --group-name browsers
+✅ firefox installed successfully
+✅ Added firefox to group 'browsers'
+
+$ anvil install chrome --group-name browsers
+✅ chrome installed successfully
+✅ Added chrome to group 'browsers'
+
+# Install and organize design tools
+$ anvil install figma --group-name design
+✅ figma installed successfully
+✅ Added figma to group 'design'
+
+$ anvil install sketch --group-name design
+✅ sketch installed successfully
+✅ Added sketch to group 'design'
+
+# Install and organize development tools
+$ anvil install docker --group-name devops
+✅ docker installed successfully
+✅ Added docker to group 'devops'
+
+$ anvil install kubernetes-cli --group-name devops
+✅ kubernetes-cli installed successfully
+✅ Added kubernetes-cli to group 'devops'
+
+# Verify your organized groups
+$ anvil install --list
+
+=== Available Groups ===
+Built-in Groups:
+  • dev: git, zsh, iterm2, visual-studio-code
+  • new-laptop: slack, google-chrome, 1password
+
+Custom Groups:
+  • browsers: firefox, chrome
+  • design: figma, sketch
+  • devops: docker, kubernetes-cli
+
+Individually Tracked Apps:
+  (none - all apps are organized in groups)
+```
+
 ## Development Workflows
 
 ### Example 4: Frontend Developer Setup

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -241,6 +241,25 @@ anvil install firefox --dry-run
 
 **🎯 Automatic Tracking**: Individual apps are automatically added to `tools.installed_apps` in your settings.yaml.
 
+### Installing Applications with Group Assignment
+
+Install applications and automatically organize them into groups:
+
+```bash
+# Add to existing group
+anvil install firefox --group-name essentials
+anvil install chrome --group-name browsers
+
+# Create new group and add app
+anvil install final-cut --group-name editing
+anvil install premiere --group-name editing
+
+# Preview with group assignment
+anvil install sketch --group-name design --dry-run
+```
+
+**🎯 Group Organization**: Apps are added to specified groups instead of `installed_apps`, creating logical collections for easy management.
+
 ### How Individual App Installation Works
 
 1. **Dynamic Detection**: Works with any Homebrew package

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,6 +32,26 @@ anvil install visual-studio-code
 - Smart deduplication prevents tracking apps already in groups or required_tools
 - Works with any Homebrew package name
 
+### Individual Application Installation with Group Assignment
+
+Install an application and automatically add it to a group:
+
+```bash
+# Add to existing group
+anvil install firefox --group-name essentials
+
+# Create new group and add app
+anvil install final-cut --group-name editing
+```
+
+**Features:**
+
+- Installs the application using existing logic
+- Adds the app to the specified group if installation is successful
+- Creates the group if it doesn't exist
+- Prevents duplicate apps within the same group
+- Falls back to normal `installed_apps` tracking if group operation fails
+
 ### Group Installation
 
 Install all tools in a predefined or custom group:
@@ -145,6 +165,10 @@ anvil install dev
 # Add individual tools as needed
 anvil install docker
 anvil install postman
+
+# Add tools to specific groups
+anvil install terraform --group-name devops
+anvil install kubernetes-cli --group-name devops
 ```
 
 ### New Machine Setup
@@ -157,6 +181,11 @@ anvil install new-laptop
 anvil install notion
 anvil install spotify
 anvil install discord
+
+# Organize apps into logical groups
+anvil install firefox --group-name browsers
+anvil install chrome --group-name browsers
+anvil install safari --group-name browsers
 ```
 
 ### Custom Workflow
@@ -171,6 +200,11 @@ anvil install frontend
 # Add specific tools
 anvil install figma --dry-run
 anvil install figma
+
+# Create and populate custom groups
+anvil install sketch --group-name design
+anvil install adobe-creative-cloud --group-name design
+anvil install figma --group-name design
 ```
 
 ### Team Setup

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -371,6 +371,36 @@ func UpdateGroupTools(groupName string, tools []string) error {
 	return SaveConfig(config)
 }
 
+// AddAppToGroup adds an app to a group, creating the group if it doesn't exist
+func AddAppToGroup(groupName string, appName string) error {
+	config, err := getCachedConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Initialize groups map if it doesn't exist
+	if config.Groups == nil {
+		config.Groups = make(map[string][]string)
+	}
+
+	// Check if the group exists
+	if tools, exists := config.Groups[groupName]; exists {
+		// Check if app is already in the group to avoid duplicates
+		for _, tool := range tools {
+			if tool == appName {
+				return nil // App already in group, no need to add
+			}
+		}
+		// Add app to existing group
+		config.Groups[groupName] = append(tools, appName)
+	} else {
+		// Create new group with the app
+		config.Groups[groupName] = []string{appName}
+	}
+
+	return SaveConfig(config)
+}
+
 // CheckEnvironmentConfigurations checks local environment configurations
 func CheckEnvironmentConfigurations() []string {
 	var warnings []string


### PR DESCRIPTION
# 🚀 Add --group-name flag to anvil install command

## 📋 **Overview**
This MR introduces the `--group-name` flag to the `anvil install` command, enabling users to install individual applications and automatically organize them into logical groups. This feature enhances workflow organization while maintaining full backward compatibility.

## ✨ **Features Added**

### **Core Functionality**
- **Group Assignment**: Install apps and automatically add them to existing or new groups
- **Dynamic Group Creation**: Creates new groups automatically if they don't exist
- **Duplicate Prevention**: Prevents adding the same app multiple times to a group
- **Graceful Fallback**: Falls back to normal `installed_apps` tracking if group operations fail

### **Usage Examples**
```bash
# Add to existing group
anvil install firefox --group-name essentials

# Create new group and add app
anvil install final-cut --group-name editing

# Preview with group assignment
anvil install sketch --group-name design --dry-run