### PR TITLE
fix: Remove lipo dependency from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,12 @@ jobs:
         shasum -a 256 * > checksums.txt
         cat checksums.txt
 
-    - name: Create universal macOS binary
+    - name: Create universal macOS binary (macOS only)
       run: |
-        # Create universal binary for macOS (combines Intel + Apple Silicon)
-        lipo -create -output dist/anvil-darwin-universal dist/anvil-darwin-amd64 dist/anvil-darwin-arm64
-        
-        # Update checksums
-        cd dist
-        shasum -a 256 anvil-darwin-universal >> checksums.txt
+        # Note: We can't create universal binaries on Linux, so we'll provide separate arch binaries
+        # Users can download the appropriate one, or we could set up a macOS runner for this step
+        echo "Skipping universal binary creation on Linux runner"
+        echo "Providing separate intel and arm64 binaries instead"
 
     - name: Create release
       uses: softprops/action-gh-release@v1
@@ -74,13 +72,6 @@ jobs:
           ## 🎉 Anvil ${{ steps.version.outputs.VERSION }}
           
           ### 📦 Installation
-          
-          **macOS (Recommended - Universal Binary):**
-          ```bash
-          curl -L https://github.com/rocajuanma/anvil/releases/download/${{ steps.version.outputs.VERSION }}/anvil-darwin-universal -o anvil
-          chmod +x anvil
-          sudo mv anvil /usr/local/bin/
-          ```
           
           **macOS Intel:**
           ```bash
@@ -115,7 +106,6 @@ jobs:
           
           **🐛 Issues?** Report them [here](https://github.com/rocajuanma/anvil/issues)
         files: |
-          dist/anvil-darwin-universal
           dist/anvil-darwin-amd64
           dist/anvil-darwin-arm64
           dist/anvil-linux-amd64

--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ curl -sSL https://raw.githubusercontent.com/rocajuanma/anvil/main/install.sh | b
 
 **Manual Download:**
 ```bash
-# macOS Universal (Intel + Apple Silicon)
-curl -L https://github.com/rocajuanma/anvil/releases/latest/download/anvil-darwin-universal -o anvil
-chmod +x anvil && sudo mv anvil /usr/local/bin/
-
 # macOS Intel
 curl -L https://github.com/rocajuanma/anvil/releases/latest/download/anvil-darwin-amd64 -o anvil
 chmod +x anvil && sudo mv anvil /usr/local/bin/

--- a/install.sh
+++ b/install.sh
@@ -86,21 +86,9 @@ install_anvil() {
     
     print_status "Installing Anvil $version for $os-$arch"
     
-    # Use universal binary for macOS if available, otherwise use architecture-specific
-    if [ "$os" = "darwin" ]; then
-        local binary_name="anvil-darwin-universal"
-        local download_url="https://github.com/$REPO/releases/download/$version/$binary_name"
-        
-        # Check if universal binary exists, fallback to arch-specific
-        if ! curl -s --head "$download_url" | head -n 1 | grep -q "200 OK"; then
-            print_warning "Universal binary not available, using architecture-specific binary"
-            binary_name="anvil-$os-$arch"
-            download_url="https://github.com/$REPO/releases/download/$version/$binary_name"
-        fi
-    else
-        local binary_name="anvil-$os-$arch"
-        local download_url="https://github.com/$REPO/releases/download/$version/$binary_name"
-    fi
+    # Use architecture-specific binaries
+    local binary_name="anvil-$os-$arch"
+    local download_url="https://github.com/$REPO/releases/download/$version/$binary_name"
     
     print_status "Downloading from: $download_url"
     


### PR DESCRIPTION
- Remove universal binary creation (requires macOS runner)
- Use architecture-specific binaries instead
- Update install script and documentation accordingly