### PR TITLE
feat[update]: add  command for updating to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ github:
 | `install [app]`     | Install application    | `anvil install terraform`   |
 | `install [group]`   | Install tool group     | `anvil install dev`         |
 | `install --list`    | List available groups  | `anvil install --list`      |
+| `update`            | Update to latest version| `anvil update`             |
 | `config pull [app]` | Pull configurations    | `anvil config pull neovim`  |
 | `config show [app]` | Show configurations    | `anvil config show neovim`  |
 | `config sync [app]` | Apply pulled configs   | `anvil config sync cursor`  |
@@ -270,6 +271,7 @@ github:
 | **[Getting Started](docs/GETTING_STARTED.md)** | Complete setup and first workflows       |
 | **[Installation Guide](docs/INSTALLATION.md)** | Platform-specific installation           |
 | **[Install Command](docs/install.md)**         | Deep-dive on tool installation           |
+| **[Update Command](docs/update.md)**           | Keep Anvil up-to-date with latest features |
 | **[Configuration Management](docs/config.md)** | Complete config sync setup and workflows |
 | **[Clean Command](docs/clean.md)**             | Directory cleanup and maintenance        |
 | **[Doctor Command](docs/doctor.md)**           | Health checks and environment validation |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rocajuanma/anvil/cmd/doctor"
 	"github.com/rocajuanma/anvil/cmd/initcmd"
 	"github.com/rocajuanma/anvil/cmd/install"
+	"github.com/rocajuanma/anvil/cmd/update"
 	"github.com/rocajuanma/anvil/pkg/constants"
 	"github.com/spf13/cobra"
 )
@@ -71,6 +72,7 @@ func init() {
 	rootCmd.AddCommand(config.ConfigCmd)
 	rootCmd.AddCommand(doctor.DoctorCmd)
 	rootCmd.AddCommand(clean.CleanCmd)
+	rootCmd.AddCommand(update.UpdateCmd)
 
 	// Add version flag
 	rootCmd.Flags().BoolP("version", "v", false, "Show version information")

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,0 +1,118 @@
+/*
+Copyright © 2022 Juanma Roca juanmaxroca@gmail.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/rocajuanma/anvil/pkg/constants"
+	"github.com/rocajuanma/anvil/pkg/errors"
+	"github.com/rocajuanma/anvil/pkg/interfaces"
+	"github.com/rocajuanma/anvil/pkg/system"
+	"github.com/rocajuanma/anvil/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// getOutputHandler returns the global output handler for terminal operations
+func getOutputHandler() interfaces.OutputHandler {
+	return terminal.GetGlobalOutputHandler()
+}
+
+// UpdateCmd represents the update command
+var UpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update Anvil to the latest version",
+	Long:  constants.UPDATE_COMMAND_LONG_DESCRIPTION,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runUpdateCommand(cmd); err != nil {
+			getOutputHandler().PrintError("Update failed: %v", err)
+			return
+		}
+	},
+}
+
+// runUpdateCommand executes the update process
+func runUpdateCommand(cmd *cobra.Command) error {
+	o := getOutputHandler()
+	// Ensure we're running on macOS (following existing project pattern)
+	if runtime.GOOS != "darwin" {
+		return errors.NewPlatformError(constants.OpUpdate, "anvil",
+			fmt.Errorf("update command is only supported on macOS"))
+	}
+
+	o.PrintHeader("Updating Anvil to Latest Version")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	result, err := updateAnvil(cmd.Context(), dryRun)
+
+	if err != nil {
+		return errors.NewInstallationError(constants.OpUpdate, "anvil",
+			fmt.Errorf("failed to execute update script: %w", err))
+	}
+
+	// For dry-run mode, result will be nil. Return early
+	if dryRun {
+		return nil
+	}
+
+	if !result.Success {
+		return errors.NewInstallationError(constants.OpUpdate, "anvil",
+			fmt.Errorf("update script failed with exit code %d: %s", result.ExitCode, result.Output))
+	}
+
+	o.PrintSuccess("Anvil has been successfully updated!")
+	o.PrintInfo("Run 'anvil --version' to verify the new version")
+	o.PrintInfo("You may need to restart your terminal session for changes to take effect")
+
+	return nil
+}
+
+// updateAnvil updates Anvil to the latest version
+// it uses the curl command to download the latest installation script from GitHub releases
+func updateAnvil(ctx context.Context, dryRun bool) (*system.CommandResult, error) {
+	o := getOutputHandler()
+
+	if dryRun {
+		o.PrintInfo("Dry run mode - would update Anvil to the latest version")
+		o.PrintInfo("Command that would be executed:")
+		o.PrintInfo("curl -sSL https://github.com/rocajuanma/anvil/releases/latest/download/install.sh | bash")
+		return nil, nil
+	}
+
+	// Check if curl is available
+	if !system.CommandExists("curl") {
+		return nil, errors.NewAnvilErrorWithType(constants.OpUpdate, "curl", errors.ErrorTypeInstallation,
+			fmt.Errorf("curl is required for updating Anvil but is not available"))
+	}
+
+	o.PrintStage("Downloading and executing update script...")
+	o.PrintInfo("Fetching latest version from GitHub releases...")
+
+	// Execute the update command using the existing system package
+	result, err := system.RunCommandWithTimeout(
+		ctx,
+		"bash",
+		"-c",
+		"curl -sSL https://github.com/rocajuanma/anvil/releases/latest/download/install.sh | bash",
+	)
+
+	return result, err
+}
+func init() {
+	UpdateCmd.Flags().Bool("dry-run", false, "Show what would be updated without actually updating")
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Update Command** 🔄 - New `anvil update` command for seamless version updates
+  - **One-Command Updates** - Update to the latest Anvil version with `anvil update`
+  - **Safe Update Process** - Uses the same trusted installation script as initial setup
+  - **Dry-Run Preview** - Preview updates with `--dry-run` flag without making changes
+  - **macOS Optimized** - Specifically designed for macOS environments
+  - **Comprehensive Documentation** - Complete usage guide with troubleshooting
+  - **Usage**: `anvil update`, `anvil update --dry-run`
+
+## [1.1.2] - 2025-09-03
+
+### Added
+
 - **Group Assignment for Individual App Installation** 📦 - New `--group-name` flag for the `anvil install` command
   - **Seamless Group Organization** - Install apps and automatically add them to existing or new groups
   - **Dynamic Group Creation** - Creates new groups automatically if they don't exist

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,187 @@
+# Update Command
+
+The `anvil update` command provides a simple and safe way to update your Anvil installation to the latest version.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Usage](#usage)
+- [Examples](#examples)
+- [Features](#features)
+- [How It Works](#how-it-works)
+- [Safety Considerations](#safety-considerations)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The update command downloads and executes the official Anvil installation script from GitHub releases, ensuring you always get the latest version with all the newest features and bug fixes.
+
+## Usage
+
+### Basic Syntax
+
+```bash
+anvil update [flags]
+```
+
+### Available Flags
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview the update process without actually updating |
+| `--help` | Show help information for the update command |
+
+## Examples
+
+### Update to Latest Version
+
+```bash
+# Update Anvil to the latest version
+anvil update
+```
+
+This will:
+- Download the latest release information from GitHub
+- Fetch and execute the official installation script
+- Replace your current Anvil binary with the latest version
+- Provide clear feedback on the update process
+
+### Preview Update Process
+
+```bash
+# See what would be updated without actually updating
+anvil update --dry-run
+```
+
+This will:
+- Show the command that would be executed
+- Display information about the update process
+- Exit without making any changes
+
+## Features
+
+### 🛡️ Safe Update Process
+
+The update command uses the same trusted installation script that you used for the initial installation, ensuring consistency and reliability.
+
+### 🧪 Dry-Run Support
+
+Preview exactly what will happen during the update process without making any changes to your system.
+
+### ✨ Automatic Detection
+
+The update script automatically detects your system architecture (Intel or Apple Silicon) and downloads the appropriate binary.
+
+### 🎯 macOS Optimized
+
+Specifically designed for macOS environments, following the same patterns as other Anvil commands.
+
+### 💡 Clear Feedback
+
+Provides step-by-step progress updates and helpful instructions throughout the update process.
+
+## How It Works
+
+The update command follows these steps:
+
+1. **Platform Check**: Verifies you're running on macOS (required for Anvil)
+2. **Dependency Check**: Ensures `curl` is available on your system
+3. **Download Script**: Fetches the latest installation script from GitHub releases
+4. **Execute Update**: Runs the script to install the latest Anvil binary
+5. **Validation**: Confirms the update was successful
+
+### The Update Command
+
+Under the hood, the update process executes:
+
+```bash
+curl -sSL https://github.com/rocajuanma/anvil/releases/latest/download/install.sh | bash
+```
+
+This is the same command recommended in the README for fresh installations and updates.
+
+## Safety Considerations
+
+### ✅ Safe Practices
+
+- **Trusted Source**: Downloads only from official GitHub releases
+- **Same Script**: Uses identical installation script as initial setup
+- **Validation**: Verifies the update process completed successfully
+- **No Data Loss**: Your `~/.anvil/settings.yaml` and configurations remain unchanged
+
+### ⚠️ Important Notes
+
+- **Terminal Restart**: You may need to restart your terminal session for changes to take effect
+- **Admin Permissions**: The script may request admin permissions to install to `/usr/local/bin/`
+- **Internet Required**: Requires active internet connection to download the latest version
+
+## Troubleshooting
+
+### Common Issues
+
+#### "curl is required but not available"
+
+**Cause**: The `curl` command is not installed or not in your PATH.
+
+**Solution**: 
+```bash
+# Install curl using Homebrew
+brew install curl
+
+# Or check if it's already available
+which curl
+```
+
+#### "Update script failed"
+
+**Cause**: Network issues, GitHub API rate limits, or permission problems.
+
+**Solutions**:
+1. **Check Internet Connection**: Ensure you have a stable internet connection
+2. **Try Again**: GitHub API has rate limits; wait a few minutes and retry
+3. **Manual Installation**: Download the binary manually from [GitHub releases](https://github.com/rocajuanma/anvil/releases)
+
+#### "Permission Denied"
+
+**Cause**: Insufficient permissions to write to `/usr/local/bin/`.
+
+**Solution**: The installation script will automatically request admin permissions when needed.
+
+#### Update Doesn't Take Effect
+
+**Cause**: Your terminal is using a cached version of the Anvil binary.
+
+**Solutions**:
+1. **Restart Terminal**: Close and reopen your terminal application
+2. **Reload PATH**: Run `hash -r` to clear the command cache
+3. **Verify Installation**: Check with `which anvil` and `anvil --version`
+
+### Getting Help
+
+If you continue to experience issues:
+
+1. **Check Version**: Run `anvil --version` to verify your current version
+2. **Check Installation**: Run `which anvil` to see where Anvil is installed
+3. **Manual Download**: Visit [GitHub releases](https://github.com/rocajuanma/anvil/releases) for manual installation
+4. **Report Issues**: Open an issue on the [GitHub repository](https://github.com/rocajuanma/anvil/issues)
+
+## Integration with Other Commands
+
+The update command works seamlessly with other Anvil commands:
+
+```bash
+# Update Anvil and verify the new version
+anvil update
+anvil --version
+
+# Run health checks after update
+anvil doctor
+
+# Continue with your normal workflow
+anvil install dev
+anvil config pull
+```
+
+---
+
+**Next Steps**: After updating, consider running `anvil doctor` to ensure your environment is properly configured with the latest version.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,6 +27,7 @@ const (
 	OpSync    = "sync"
 	OpDoctor  = "doctor"
 	OpClean   = "clean"
+	OpUpdate  = "update"
 )
 
 // System command constants

--- a/pkg/constants/descriptions.go
+++ b/pkg/constants/descriptions.go
@@ -229,3 +229,27 @@ Safety features:
 • Force flag available for automated scripts
 
 This command is safe and will never delete your main configuration file. The dotfiles directory will be completely removed to ensure the next pull/push operation works seamlessly.`
+
+// Update command descriptions
+const UPDATE_COMMAND_LONG_DESCRIPTION = `The update command updates Anvil to the latest version by downloading and running
+the official installation script from GitHub releases.
+
+What it does:
+• 🔄 Downloads the latest release version information from GitHub
+• 📥 Fetches the official installation script from the releases
+• 🚀 Executes the script to install the latest Anvil binary
+• ✅ Replaces the current installation with the newest version
+• 🔍 Validates the update process and provides clear feedback
+
+Features:
+• 🛡️ Safe Update Process: Uses the same trusted installation script as initial setup
+• 🧪 Dry-Run Support: Preview the update process without actually updating using --dry-run
+• ✨ Automatic Detection: Detects your system architecture and downloads the appropriate binary
+• 🎯 macOS Optimized: Specifically designed for macOS environments
+• 💡 Clear Feedback: Provides step-by-step progress and helpful instructions
+
+Usage:
+• anvil update           - Update to the latest version
+• anvil update --dry-run - Preview what would be updated
+
+Perfect for keeping your Anvil installation up-to-date with the latest features and bug fixes.`


### PR DESCRIPTION
# 🚀 Add `anvil update` Command

## 📋 Summary

This MR introduces a new `anvil update` command that allows users to easily update their Anvil installation to the latest version using the official installation script from GitHub releases.

## 🎯 What's Changed

### ✨ New Features

- **New `anvil update` command** - Updates Anvil to the latest version
- **Dry-run support** - Preview updates with `--dry-run` flag without making changes
- **Comprehensive documentation** - Complete user guide with examples and troubleshooting

## 🛠 Technical Implementation

The command executes:
```bash
curl -sSL https://github.com/rocajuanma/anvil/releases/latest/download/install.sh | bash
```


## 💡 Usage Examples

```bash
# Update to latest version
anvil update

# Preview what would be updated
anvil update --dry-run

# Get help
anvil update --help
```

## 🎉 Impact

This enhancement makes it significantly easier for users to keep their Anvil installation up-to-date with the latest features and bug fixes, improving the overall user experience and reducing support overhead.