### PR TITLE
fix[format]: output formating inconsistencies

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -220,7 +220,7 @@ func installGroupSerial(groupName string, tools []string, dryRun bool) error {
 	var installErrors []string
 
 	for i, tool := range tools {
-		getOutputHandler().PrintProgress(i+1, len(tools), fmt.Sprintf("Installing %s", tool))
+		getOutputHandler().PrintProgress(i+1, len(tools), fmt.Sprintf("\nInstalling %s", tool))
 
 		// Use unified installation logic - this ensures consistent behavior with availability checking
 		_, err := installSingleToolUnified(tool, dryRun)
@@ -325,7 +325,7 @@ func installSingleToolUnified(toolName string, dryRun bool) (wasNewlyInstalled b
 	// Handle installation based on mode
 	if dryRun {
 		o.PrintInfo("Would install: %s", toolName)
-		return true, nil // Would be newly installed
+		return true, nil
 	}
 
 	// Perform real installation using existing logic

--- a/pkg/terminal/output.go
+++ b/pkg/terminal/output.go
@@ -180,11 +180,11 @@ func (oh *DefaultOutputHandler) PrintAlreadyAvailable(format string, args ...int
 	message := fmt.Sprintf(format, args...)
 
 	if oh.config.UseColors && oh.config.UseEmojis && oh.config.UseFormatting {
-		fmt.Printf("%s%s💙 %s%s\n", ColorBold, ColorBlue, message, ColorReset)
+		fmt.Printf("\n%s%s💙 %s%s\n", ColorBold, ColorBlue, message, ColorReset)
 	} else if oh.config.UseColors {
-		fmt.Printf("%s%s[AVAILABLE] %s%s\n", ColorBold, ColorBlue, message, ColorReset)
+		fmt.Printf("\n%s%s[AVAILABLE] %s%s\n", ColorBold, ColorBlue, message, ColorReset)
 	} else {
-		fmt.Printf("[AVAILABLE] %s\n", message)
+		fmt.Printf("\n[AVAILABLE] %s\n", message)
 	}
 }
 


### PR DESCRIPTION
- Fix minor issues with terminal output formatting while running certain commands. Functionality is not affected, just ensuring the output is readable, correct and consistent.