### PR TITLE
bug[brew]: duplicate install fix and logic refactor

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -93,12 +93,6 @@ func runInstallCommand(cmd *cobra.Command, target string) error {
 	if err := brew.EnsureBrewIsInstalled(); err != nil {
 		return fmt.Errorf("install: %w", err)
 	}
-	// Update Homebrew before installations
-	o.PrintStage("Updating Homebrew...")
-	if err := brew.UpdateBrew(); err != nil {
-		o.PrintWarning("Failed to update Homebrew: %v", err)
-		// Continue anyway, update failure shouldn't stop installation
-	}
 
 	// Try to get group tools first
 	if tools, err := config.GetGroupTools(target); err == nil {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -90,14 +90,9 @@ func runInstallCommand(cmd *cobra.Command, target string) error {
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 
 	// Ensure Homebrew is installed
-	if !brew.IsBrewInstalled() {
-		o.PrintInfo("Homebrew not found. Installing Homebrew...")
-		if err := brew.InstallBrew(); err != nil {
-			return errors.NewInstallationError(constants.OpInstall, "homebrew", err)
-		}
-		o.PrintSuccess("Homebrew installed successfully")
+	if err := brew.EnsureBrewIsInstalled(); err != nil {
+		return fmt.Errorf("install: %w", err)
 	}
-
 	// Update Homebrew before installations
 	o.PrintStage("Updating Homebrew...")
 	if err := brew.UpdateBrew(); err != nil {

--- a/pkg/brew/brew.go
+++ b/pkg/brew/brew.go
@@ -40,6 +40,21 @@ type BrewPackage struct {
 	Installed   bool
 }
 
+// EnsureBrewIsInstalled ensures Homebrew is installed
+func EnsureBrewIsInstalled() error {
+	if !IsBrewInstalled() {
+		getOutputHandler().PrintInfo("Homebrew not found. Installing Homebrew...")
+		if err := InstallBrew(); err != nil {
+			return fmt.Errorf("failed to install Homebrew: %w", err)
+		}
+		getOutputHandler().PrintSuccess("Homebrew installed successfully")
+	} else {
+		getOutputHandler().PrintInfo("✓ Homebrew is available")
+	}
+
+	return nil
+}
+
 // IsBrewInstalled checks if Homebrew is installed
 func IsBrewInstalled() bool {
 	return system.CommandExists(constants.BrewCommand)


### PR DESCRIPTION
# Fix: Eliminate Duplicate Homebrew Installation in `anvil init`

## Problem
`anvil init` was attempting to install Homebrew twice, causing "exit status 1" failures for users without Homebrew pre-installed.

## Root Cause
Homebrew was handled in two phases:
1. **Phase 1**: Direct prerequisite installation
2. **Phase 2**: Regular tool validation (where Homebrew was also included as a tool)

This caused duplicate installation attempts and initialization failures.

## Solution
Refactored Homebrew to be handled **only as a prerequisite**, removing it from the regular tools validation loop.
