### PR TITLE
opt[brew]: enhance brew installation, validation and logic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced progress display formatting to prevent line concatenation issues
 
 ### Fixed
+- **Homebrew Installation Reliability** 🔧 - Fixed PATH detection and prerequisites validation
+  - Added post-installation verification and enhanced PATH checking
+  - Improved error reporting with actual installation script output
+  - Added Xcode Command Line Tools validation before installation
+  - **Issue**: PATH refresh problems and missing prerequisites caused installation failures
+
 - **Duplicate Homebrew Installation** 🔧 - Fixed `anvil init` attempting to install Homebrew twice causing exit status 1 failures
   - Removed Homebrew from regular tools validation loop, now handled only as prerequisite  
   - **Issue**: Users without Homebrew pre-installed experienced initialization failures due to duplicate installation attempts

--- a/pkg/brew/brew.go
+++ b/pkg/brew/brew.go
@@ -95,7 +95,11 @@ func InstallBrew() error {
 	}
 
 	if !result.Success {
-		return fmt.Errorf("brew installation failed: %s", result.Error)
+		errorDetails := result.Error
+		if result.Output != "" {
+			errorDetails = fmt.Sprintf("%s\nOutput: %s", result.Error, strings.TrimSpace(result.Output))
+		}
+		return fmt.Errorf("brew installation failed: %s", errorDetails)
 	}
 
 	if !IsBrewInstalledAtPath() {

--- a/pkg/brew/brew.go
+++ b/pkg/brew/brew.go
@@ -85,6 +85,11 @@ func InstallBrew() error {
 		return nil
 	}
 
+	xcodeResult, err := system.RunCommand("xcode-select", "-p")
+	if err != nil || !xcodeResult.Success {
+		return fmt.Errorf("Xcode Command Line Tools required for Homebrew installation. Install with: xcode-select --install")
+	}
+
 	getOutputHandler().PrintInfo("Installing Homebrew...")
 
 	installCmd := `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`

--- a/pkg/brew/brew.go
+++ b/pkg/brew/brew.go
@@ -58,6 +58,23 @@ func IsBrewInstalled() bool {
 	return system.CommandExists(constants.BrewCommand)
 }
 
+// IsBrewInstalledAtPath checks if Homebrew is installed at known paths
+func IsBrewInstalledAtPath() bool {
+	brewPaths := []string{
+		"/opt/homebrew/bin/brew", // Apple Silicon
+		"/usr/local/bin/brew",    // Intel
+	}
+
+	for _, path := range brewPaths {
+		result, err := system.RunCommand("test", "-x", path)
+		if err == nil && result.Success {
+			return true
+		}
+	}
+
+	return system.CommandExists("brew")
+}
+
 // InstallBrew installs Homebrew if not already installed
 func InstallBrew() error {
 	if runtime.GOOS != "darwin" {
@@ -70,7 +87,6 @@ func InstallBrew() error {
 
 	getOutputHandler().PrintInfo("Installing Homebrew...")
 
-	// Official Homebrew installation command
 	installCmd := `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 
 	result, err := system.RunCommand("/bin/bash", "-c", installCmd)
@@ -80,6 +96,10 @@ func InstallBrew() error {
 
 	if !result.Success {
 		return fmt.Errorf("brew installation failed: %s", result.Error)
+	}
+
+	if !IsBrewInstalledAtPath() {
+		return fmt.Errorf("Homebrew installation completed but brew command not accessible")
 	}
 
 	return nil


### PR DESCRIPTION
# 🔧 Fix: Homebrew Installation Reliability and Output Formatting

## Problem
- Homebrew installation reported success but command remained inaccessible (PATH refresh issue)
- Poor error messages with repetitive wrapping
- Missing prerequisites validation
- Confusing terminal output formatting

## Solution
### Homebrew Installation Fixes
- **Added post-installation verification** - Checks known brew paths (`/opt/homebrew/bin/brew`, `/usr/local/bin/brew`) to prevent false success
- **Enhanced PATH detection** - Resolves issue where current process doesn't inherit updated PATH after installation
- **Improved error reporting** - Includes actual installation script output for better debugging
- **Added Xcode CLT validation** - Fast check with clear error message: "Xcode Command Line Tools required for Homebrew installation"
- **Eliminated duplicate installations** - Removed Homebrew from tools validation loop, handled only as prerequisite
