### PR TITLE
bug[install]: resolve fresh installation bug when /usr/local/bin did not exist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Installation Script Directory Creation** 🔧 - Fixed installation failure on fresh macOS systems
+  - Installation script now creates `/usr/local/bin` directory if it doesn't exist
+  - Resolves "No such file or directory" error when installing on systems without Homebrew or other package managers
+  - **Issue**: Installation failed on fresh Mac systems where `/usr/local/bin` directory didn't exist
 
 ## [1.5.0] - 2025-10-01
 

--- a/install.sh
+++ b/install.sh
@@ -116,6 +116,16 @@ install_anvil() {
     # Install binary
     print_status "Installing to $INSTALL_DIR/$BINARY_NAME"
     
+    # Create install directory if it doesn't exist
+    if [ ! -d "$INSTALL_DIR" ]; then
+        print_status "Creating directory $INSTALL_DIR"
+        if ! sudo mkdir -p "$INSTALL_DIR"; then
+            print_error "Failed to create directory $INSTALL_DIR"
+            rm -rf "$tmp_dir"
+            exit 1
+        fi
+    fi
+    
     if [ -w "$INSTALL_DIR" ]; then
         mv "$tmp_file" "$INSTALL_DIR/$BINARY_NAME"
     else


### PR DESCRIPTION
This bug happens in a fresh mac installation where Homebrew is not installed. This local directory needs to be created before the binary can be moved into it.


Resolves https://github.com/rocajuanma/anvil/issues/174