### PR TITLE
fix[init]: force interactive mode for homebrew installer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- **Homebrew Installation Interactive Mode** 🔧 - Fixed Homebrew installer running in non-interactive mode by setting INTERACTIVE=1 environment variable to force password prompts even when TTY detection fails through subprocess chain
 - **Homebrew Installation Script Execution** 🔧 - Fixed Homebrew installer script being printed instead of executed by properly piping curl output to bash
 
 ## [2.2.1] - 2025-10-13

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -142,12 +142,18 @@ func SetEnvironmentVariable(key, value string) error {
 
 // RunInteractiveCommand executes a command with stdin, stdout, and stderr connected to the terminal.
 // This is required for commands that need user interaction (e.g., sudo password prompts).
+// Sets INTERACTIVE=1 environment variable to force interactive mode even when TTY detection fails.
 func RunInteractiveCommand(command string, args ...string) error {
 	cmd := exec.Command(command, args...)
 
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	
+	// Preserve existing environment and add INTERACTIVE=1
+	// This forces tools like Homebrew installer to run in interactive mode
+	// even when they can't detect a TTY through the subprocess chain
+	cmd.Env = append(os.Environ(), "INTERACTIVE=1")
 
 	return cmd.Run()
 }


### PR DESCRIPTION
Fixes `anvil init` Homebrew installation failures on fresh macOS systems by forcing interactive mode upon homebrew installation.