### PR TITLE
feat[brew]: add support for homebrew installation

### DIFF
--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -1,0 +1,20 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  update-tap:
+    name: Update Homebrew Formula
+    uses: 0xjuanma/simple-release/.github/workflows/reusable-update-tap.yml@main
+    with:
+      tap-repo: '0xjuanma/homebrew-tap'
+      project-name: 'anvil'
+      formula-path: 'anvil.rb'
+      github-repo: '0xjuanma/anvil'
+    secrets:
+      token: ${{ secrets.TAP_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ Save hours in your process — install the tools you need, sync your configs, an
 
 ### Installation
 
-**New installations:**
+**Via install script (Recommended for fresh machines):**
 ```bash
 curl -sSL https://github.com/0xjuanma/anvil/releases/latest/download/install.sh | bash
+```
+*Note: Ideal for new machines without Homebrew - Anvil will install it during the `anvil init` step.*
+
+**Via Homebrew (If you already have Homebrew installed):**
+```bash
+brew install 0xjuanma/tap/anvil
 ```
 
 **Update existing installation:**

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -21,6 +21,10 @@ package update
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/0xjuanma/anvil/internal/constants"
 	"github.com/0xjuanma/anvil/internal/errors"
@@ -45,21 +49,31 @@ func runUpdateCommand(cmd *cobra.Command) error {
 
 	o.PrintHeader("Updating Anvil to Latest Version")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	result, err := updateAnvil(cmd.Context(), dryRun)
 
-	if err != nil {
-		return errors.NewInstallationError(constants.OpUpdate, constants.ANVIL,
-			fmt.Errorf("failed to execute update script: %w", err))
-	}
+	// Detect installation method
+	installMethod := detectInstallationMethod()
 
-	// For dry-run mode, result will be nil. Return early
 	if dryRun {
+		o.PrintInfo("Dry run mode - would update Anvil to the latest version")
+		o.PrintInfo("Detected installation method: %s", installMethod)
+		if installMethod == "homebrew" {
+			o.PrintInfo("Command that would be executed: brew upgrade 0xjuanma/tap/anvil")
+		} else {
+			o.PrintInfo("Command that would be executed: curl -sSL %s | bash", constants.UpdateReleaseScriptURL)
+		}
 		return nil
 	}
 
-	if !result.Success {
+	var err error
+	if installMethod == "homebrew" {
+		err = updateViaHomebrew(cmd.Context())
+	} else {
+		err = updateViaScript(cmd.Context())
+	}
+
+	if err != nil {
 		return errors.NewInstallationError(constants.OpUpdate, constants.ANVIL,
-			fmt.Errorf("update script failed with exit code %d: %s", result.ExitCode, result.Output))
+			fmt.Errorf("failed to update: %w", err))
 	}
 
 	o.PrintSuccess("Anvil has been successfully updated!")
@@ -69,25 +83,80 @@ func runUpdateCommand(cmd *cobra.Command) error {
 	return nil
 }
 
-// updateAnvil updates Anvil to the latest version by downloading and
-// executing the installation script from GitHub releases with fallback to main branch.
-func updateAnvil(ctx context.Context, dryRun bool) (*system.CommandResult, error) {
+// detectInstallationMethod returns "homebrew" or "script" based on how anvil was installed.
+func detectInstallationMethod() string {
+	// 1. Check if binary is a Homebrew symlink
+	if isHomebrewInstall() {
+		return "homebrew"
+	}
+
+	// 2. Check if brew knows about the package
+	if isBrewPackageInstalled() {
+		return "homebrew"
+	}
+
+	// 3. Default to script
+	return "script"
+}
+
+// isHomebrewInstall checks if binary is in Homebrew Cellar.
+func isHomebrewInstall() bool {
+	execPath, err := os.Executable()
+	if err != nil {
+		return false
+	}
+
+	realPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return false
+	}
+
+	// Check if resolved path contains Homebrew Cellar (macOS or Linux)
+	return strings.Contains(realPath, "/Cellar/anvil/")
+}
+
+// isBrewPackageInstalled checks if brew knows about anvil.
+func isBrewPackageInstalled() bool {
+	cmd := exec.Command("brew", "--prefix", "anvil")
+	err := cmd.Run()
+	return err == nil
+}
+
+// updateViaHomebrew updates Anvil using Homebrew.
+func updateViaHomebrew(ctx context.Context) error {
 	o := palantir.GetGlobalOutputHandler()
 
-	if dryRun {
-		o.PrintInfo("Dry run mode - would update Anvil to the latest version")
-		o.PrintInfo("Command that would be executed:")
-		o.PrintInfo("curl -sSL %s | bash", constants.UpdateReleaseScriptURL)
-		return nil, nil
+	o.PrintStage("Detected Homebrew installation. Updating via brew...")
+
+	// Check if brew is available
+	if !system.CommandExists("brew") {
+		return fmt.Errorf("brew command not found")
 	}
+
+	result, err := system.RunCommandWithTimeout(ctx, "brew", "upgrade", "0xjuanma/tap/anvil")
+	if err != nil {
+		return fmt.Errorf("failed to execute brew upgrade: %w", err)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("brew upgrade failed with exit code %d: %s", result.ExitCode, result.Output)
+	}
+
+	return nil
+}
+
+// updateViaScript updates Anvil using the installation script.
+func updateViaScript(ctx context.Context) error {
+	o := palantir.GetGlobalOutputHandler()
+
+	o.PrintStage("Updating via install script...")
 
 	// Check if curl is available
 	if !system.CommandExists("curl") {
-		return nil, errors.NewAnvilErrorWithType(constants.OpUpdate, "curl", errors.ErrorTypeInstallation,
+		return errors.NewAnvilErrorWithType(constants.OpUpdate, "curl", errors.ErrorTypeInstallation,
 			fmt.Errorf("curl is required for updating Anvil but is not available"))
 	}
 
-	o.PrintStage("Downloading and executing update script...")
 	o.PrintInfo("Fetching latest version from GitHub releases...")
 
 	// Try downloading from releases first, fallback to main branch if that fails
@@ -111,8 +180,17 @@ func updateAnvil(ctx context.Context, dryRun bool) (*system.CommandResult, error
 		updateScript,
 	)
 
-	return result, err
+	if err != nil {
+		return fmt.Errorf("failed to execute update script: %w", err)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("update script failed with exit code %d: %s", result.ExitCode, result.Output)
+	}
+
+	return nil
 }
+
 func init() {
 	UpdateCmd.Flags().Bool("dry-run", false, "Show what would be updated without actually updating")
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Homebrew Installation** - Anvil can now be installed via Homebrew using `brew install 0xjuanma/tap/anvil`
 
 ### Changed
+- **Smart Update Detection** - The `anvil update` command now automatically detects whether Anvil was installed via Homebrew or script, and uses the appropriate update method (`brew upgrade` vs install script)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/0xjuanma/anvil/issues/165

Adds Homebrew tap installation support and smart update detection for Anvil.

## Updates
- Added Homebrew installation option via `brew install 0xjuanma/tap/anvil`
- Updated `anvil update` to auto-detect installation method and use appropriate update procedure
- Updated README with both installation paths and recommendations
- Add reusable workflow to tap-update from https://github.com/0xjuanma/simple-release